### PR TITLE
Added scripts for SPO/Teams management and removed unnecessary if statement in Teams Usage Report script

### DIFF
--- a/scripts/Get-FullOwnerReport/Get-FullOwnerReport.ps1
+++ b/scripts/Get-FullOwnerReport/Get-FullOwnerReport.ps1
@@ -1,0 +1,154 @@
+﻿<#
+
+.SYNOPSIS
+  Name: Get-FullOwnerReport.ps1
+  This script looks for and reports all users and groups that have full control access for all sites and subsites
+  in a user's tenant
+
+.Requirements
+SPO PnP Module: https://github.com/SharePoint/PnP-PowerShell/releases 
+
+.PARAMETER rootSite
+  The SharePoint Online root site url
+
+.PARAMETER outputPath
+  The file path that the user wishes to contain the final report
+
+
+.OUTPUTS
+Exports data into a csv named FullOwnersReport.csv
+
+  
+.EXAMPLE
+  .\Get-FullOwnerReport.ps1 -rootSite "https://myTenant.sharepoint.com/" -outputPath "c:\users\me\documents"
+
+
+#>
+
+
+param(
+
+    [Parameter(Mandatory=$true,
+	HelpMessage="Enter sharepoint root url",
+	ValueFromPipeline=$false)]
+	$rootSite,
+    
+    [Parameter(Mandatory=$true,
+	HelpMessage="Enter file path to create CSV report in",
+	ValueFromPipeline=$false)]
+    [ValidateScript({ Test-Path $_ -PathType Container  })]
+	$outputPath
+)
+
+#import SharePointPnPPowerShellOnline
+
+    try
+    {
+
+    Import-Module SharePointPnPPowerShellOnline -ErrorAction Stop
+
+    }
+    catch
+    {
+
+    
+    Start-Process -FilePath "powershell" -Verb runas -ArgumentList "Install-Module SharePointPnPPowerShellOnline -Force -AllowClobber;" -Wait
+    Import-Module SharePointPnPPowerShellOnline
+
+    }
+
+
+
+$spcred = Get-Credential
+
+$allSubSites = @()
+$urls = @()
+
+$allGroupSites = @()
+
+Connect-PNPonline -Url "$($rootSite)" -Credentials $spcred 
+
+$urls = Get-PnPTenantSite -Url "$rootSite"  -IncludeOneDriveSites  -Detailed
+
+
+foreach($url in $urls)
+{
+
+try
+{
+
+Connect-PNPonline -Url "$($url.Url)" -Credentials $spcred -ErrorAction SilentlyContinue
+$allSubSites += Get-PnPSubWebs -Recurse -ErrorAction SilentlyContinue
+
+}
+catch
+{
+
+Write-Warning -Message "Warning Access to $($url.Url) was denied."
+
+}
+
+}
+
+$allSubSites += $urls
+
+$allOwners = @()
+
+foreach($url in $allSubSites)
+{
+
+try
+{
+
+Connect-PNPonline -Url "$($url.Url)" -Credentials $spcred -ErrorAction Stop
+
+$owners  = Get-PnPGroup -ErrorAction Stop | where {$_.Title -match "Owners"} 
+
+
+foreach($owner in $owners)
+{
+
+$allOwnerGroups  = Get-PnPGroupMembers -Identity "$($owner.Title)"
+Write-Host "Accessing users of group $($owner.Title)"
+
+foreach($lowerOwner in $allOwnerGroups)
+{
+
+Write-Host "User $($lowerOwner.LoginName) found as owner for site $($url.Url)"
+
+$object = New-Object –TypeName PSObject
+$object | Add-Member –MemberType NoteProperty –Name LoginName –Value $lowerOwner.LoginName
+$object | Add-Member –MemberType NoteProperty –Name Email –Value $lowerOwner.Email
+$object | Add-Member –MemberType NoteProperty –Name URL –Value "$($url.Url)"
+
+$allOwners += $object
+
+}
+
+
+}
+
+}
+catch
+{
+Write-Warning -Message "Warning Access to $($url.Url) was denied."
+}
+
+}
+
+$GroupReport = $outputPath + "\FullOwnersReport.csv"
+
+
+if((Test-Path -Path "$GroupReport"))
+{
+
+$allOwners  | Export-Csv -Path "$GroupReport" -Force -NoTypeInformation
+
+}
+else
+{
+
+New-Item -Path "$GroupReport" -ItemType file
+$allOwners  | Export-Csv -Path "$GroupReport" -Force -NoTypeInformation
+
+}

--- a/scripts/Get-FullOwnerReport/README.md
+++ b/scripts/Get-FullOwnerReport/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-The purpose of this script is to use the groups usage report graph api to gather usage data on teams within a certain period of time
+This script looks for and reports all users and groups that have full control access for all sites and subsites in a user's tenant
 
 ### Run
 

--- a/scripts/Get-FullOwnerReport/README.md
+++ b/scripts/Get-FullOwnerReport/README.md
@@ -1,0 +1,69 @@
+# Microsoft FastTrack Open Source - Get-FullOwnerReport
+
+## Usage
+
+The purpose of this script is to use the groups usage report graph api to gather usage data on teams within a certain period of time
+
+### Run
+
+1. Copy the script file "Get-FullOwnerReport.ps1" to a folder and open a PowerShell command window to that folder
+
+2. Execute the script using:
+
+`.\Get-FullOwnerReport.ps1 -rootSite "https://myTenant.sharepoint.com/" -outputPath "c:\users\me\documents"`
+
+(You may be prompted to install the nuget provider and several other libraries. This is expected so the dependencies can be auto-installed.)
+
+3. Review the produced csv file 
+
+
+|Option|Description|Default
+|----|--------------------------|--------------------------
+|rootSite|The SharePoint Online root site url|**required**
+|outputPath|The file path that the user wishes to contain the final report|**required**
+
+
+### External Dependencies
+
+SharePointPnPPowerShellOnline PowerShell Module
+
+## Applies To
+
+- SharePoint Online
+
+## Author
+
+|Author|Original Publish Date
+|----|--------------------------
+|Nicholas Switzer, Microsoft|May 22, 2018|
+
+## Issues
+
+Please report any issues you find to the [issues list](../../../../issues).
+
+## Support Statement
+
+The scripts, samples, and tools made available through the FastTrack Open Source initiative are provided as-is. These resources are developed in partnership with the community and do not represent official Microsoft software. As such, support is not available through premier or other official support channels. If you find an issue or have questions please reach out through the issues list and we'll do our best to assist, but there is no support SLA associated with these tools.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Legal Notices
+
+Microsoft and any contributors grant you a license to the Microsoft documentation and other content
+in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
+see the [LICENSE](https://github.com/Microsoft/FastTrack/blob/master/LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the
+[LICENSE-CODE](https://github.com/Microsoft/FastTrack/blob/master/LICENSE-CODE) file.
+
+Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
+may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
+The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
+Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+
+Privacy information can be found at https://privacy.microsoft.com/en-us/
+
+Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
+or trademarks, whether by implication, estoppel or otherwise.

--- a/scripts/Get-FullTeamsReport/Get-FullTeamsReport.ps1
+++ b/scripts/Get-FullTeamsReport/Get-FullTeamsReport.ps1
@@ -3,7 +3,6 @@
 .SYNOPSIS
   Name: Get-FullTeamsReport.ps1
   The purpose of this script is to report all teams, channels, and users that exists in an environment
-  is apart of
 
 .Requirements
 MicrosoftTeams PowerShell Module

--- a/scripts/Get-FullTeamsReport/Get-FullTeamsReport.ps1
+++ b/scripts/Get-FullTeamsReport/Get-FullTeamsReport.ps1
@@ -1,0 +1,174 @@
+﻿<#
+
+.SYNOPSIS
+  Name: Get-FullTeamsReport.ps1
+  The purpose of this script is to report all teams, channels, and users that exists in an environment
+  is apart of
+
+.Requirements
+MicrosoftTeams PowerShell Module
+
+.PARAMETER ReportName
+  The file path that the user wishes to contain the final report
+
+.OUTPUTS
+Exports data into an html file named according to the ReportName parameter
+
+
+.EXAMPLE
+  .\Get-FullTeamsReport.ps1 -ReportName 'MyReport'
+
+#>
+
+param(
+
+	[Parameter(Mandatory=$true,
+	HelpMessage="Please enter a name for this Report",
+	ValueFromPipeline=$false)]
+	$ReportName
+)
+
+    try
+    {
+
+    Import-Module MicrosoftTeams -ErrorAction Stop
+
+    }
+    catch
+    {
+
+    
+    Start-Process -FilePath "powershell" -Verb runas -ArgumentList "Install-Module MicrosoftTeams -Force -AllowClobber;" -Wait 
+    Import-Module MicrosoftTeams
+
+    }
+
+$allGroups = @()
+
+$creds = Get-Credential
+
+$Session365 = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $creds -Authentication Basic -AllowRedirection
+
+
+$allGroups = Invoke-Command -ScriptBlock {Get-UnifiedGroup} -Session $Session365 
+
+Remove-PSSession -Session $Session365
+
+
+Connect-MicrosoftTeams -Credential $creds
+
+
+$allChannels = @()
+$allMembers = @()
+$allOwners = @()
+$allGuests = @()
+$allInfo = @()
+
+
+
+
+foreach($team in $allGroups)
+{
+
+try
+{
+
+$channelNames = ""
+$memberNames = ""
+$ownerNames = ""
+$guestsNames = ""
+
+$allChannels = Get-TeamChannel -GroupId $($team.ExternalDirectoryObjectId) 
+
+foreach($channel in $allChannels)
+{
+$channelNames += $channel.DisplayName + ","
+}
+
+$allMembers = Get-TeamUser -GroupId $($team.ExternalDirectoryObjectId) -Role Member 
+
+foreach($members in $allMembers)
+{
+$memberNames += $members.User + ","
+}
+
+$allOwners = Get-TeamUser -GroupId $($team.ExternalDirectoryObjectId) -Role Owner 
+
+foreach($owner in $allOwners)
+{
+$ownerNames += $owner.User + ","
+}
+
+$allGuests = Get-TeamUser -GroupId $($team.ExternalDirectoryObjectId) -Role Guest 
+
+foreach($guest in $allGuests)
+{
+$guestsNames += $guest.User + ","
+}
+
+$object = New-Object -TypeName PSObject
+
+Add-Member -InputObject $object -MemberType NoteProperty -Name TeamName -Value $($team.DisplayName)
+Add-Member -InputObject $object -MemberType NoteProperty -Name channels -Value $channelNames
+Add-Member -InputObject $object -MemberType NoteProperty -Name members -Value $memberNames
+Add-Member -InputObject $object -MemberType NoteProperty -Name owners -Value $ownerNames
+Add-Member -InputObject $object -MemberType NoteProperty -Name guests -Value $guestsNames
+
+$allInfo += $object
+}
+catch
+{
+$result = $_.Exception.Message.toString()
+
+if($result -match "AccessDenied")
+{
+
+$object = New-Object -TypeName PSObject
+
+Add-Member -InputObject $object -MemberType NoteProperty -Name TeamName -Value $($team.DisplayName)
+Add-Member -InputObject $object -MemberType NoteProperty -Name channels -Value "Access Forbidden"
+Add-Member -InputObject $object -MemberType NoteProperty -Name members -Value "Access Forbidden"
+Add-Member -InputObject $object -MemberType NoteProperty -Name owners -Value "Access Forbidden"
+Add-Member -InputObject $object -MemberType NoteProperty -Name guests -Value "Access Forbidden"
+
+$allInfo += $object
+}
+
+
+}
+}
+
+$head = @"
+<Title></Title>
+<Style>
+table {
+    font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+ td,  th {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+ tr:nth-child(even){background-color: #f2f2f2;}
+
+ tr:hover {background-color: #ddd;}
+
+ th {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    text-align: left;
+    background-color: #5558af;
+    color: white;
+}
+</Style>
+
+</script>
+"@
+
+
+$allInfo | ConvertTo-Html -Head $head | Out-File -FilePath "$ReportName.html" -Force
+
+

--- a/scripts/Get-FullTeamsReport/README.md
+++ b/scripts/Get-FullTeamsReport/README.md
@@ -1,0 +1,67 @@
+# Microsoft FastTrack Open Source - Get-FullTeamsReport
+
+## Usage
+
+The purpose of this script is to use the groups usage report graph api to gather usage data on teams within a certain period of time
+
+### Run
+
+1. Copy the script file "Get-FullTeamsReport.ps1" to a folder and open a PowerShell command window to that folder
+
+2. Execute the script using:
+
+'.\Get-FullTeamsReport.ps1 -ReportName 'MyReportName''
+
+(You may be prompted to install the nuget provider and several other libraries. This is expected so the dependencies can be auto-installed.)
+
+3. Review the produced html file
+
+|Option|Description|Default
+|----|--------------------------|--------------------------
+|ReportName|The file path that the user wishes to contain the final report|**required**
+
+
+### External Dependencies
+
+MicrosoftTeams PowerShell Module
+
+## Applies To
+
+- Microsoft Teams
+
+## Author
+
+|Author|Original Publish Date
+|----|--------------------------
+|Nicholas Switzer, Microsoft|May 22, 2018|
+
+## Issues
+
+Please report any issues you find to the [issues list](../../../../issues).
+
+## Support Statement
+
+The scripts, samples, and tools made available through the FastTrack Open Source initiative are provided as-is. These resources are developed in partnership with the community and do not represent official Microsoft software. As such, support is not available through premier or other official support channels. If you find an issue or have questions please reach out through the issues list and we'll do our best to assist, but there is no support SLA associated with these tools.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Legal Notices
+
+Microsoft and any contributors grant you a license to the Microsoft documentation and other content
+in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
+see the [LICENSE](https://github.com/Microsoft/FastTrack/blob/master/LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the
+[LICENSE-CODE](https://github.com/Microsoft/FastTrack/blob/master/LICENSE-CODE) file.
+
+Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
+may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
+The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
+Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+
+Privacy information can be found at https://privacy.microsoft.com/en-us/
+
+Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
+or trademarks, whether by implication, estoppel or otherwise.

--- a/scripts/Get-FullTeamsReport/README.md
+++ b/scripts/Get-FullTeamsReport/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-The purpose of this script is to use the groups usage report graph api to gather usage data on teams within a certain period of time
+The purpose of this script is to report all teams, channels, and users that exists in an environment
 
 ### Run
 

--- a/scripts/Get-OD4BExternalUsers/Get-OD4BExternalUsers.ps1
+++ b/scripts/Get-OD4BExternalUsers/Get-OD4BExternalUsers.ps1
@@ -1,0 +1,203 @@
+﻿<#
+
+.SYNOPSIS
+  Name: Get-OD4BExternalUsers.ps1
+  The purpose of this script is to search a tenant's OD4B sites
+  for all files that are shared with external users. Once all of this data is found
+  a csv report will be created.
+
+.Requirements
+SPO Powershell Module: https://www.microsoft.com/en-us/download/details.aspx?id=35588
+SPO Client Components SDK: https://www.microsoft.com/en-us/download/details.aspx?id=42038 
+SPO PnP Module: https://github.com/SharePoint/PnP-PowerShell/releases 
+
+
+.PARAMETER rootSite
+  The SharePoint Online root site url
+
+.PARAMETER outputPath
+  The file path that the user wishes to contain the final report
+  
+.OUTPUTS
+Exports data into a csv named OD4BReportExternalUsers.csv
+
+
+.EXAMPLE
+  .\Get-OD4BExternalUser.ps1 -rootSite "https://myTenant.sharepoint.com/" -outputPath "c:\users\me\documents"
+
+
+#>
+
+
+param(
+
+    [Parameter(Mandatory=$true,
+	HelpMessage="Enter sharepoint root url",
+	ValueFromPipeline=$false)]
+	$rootSite,
+    
+    [Parameter(Mandatory=$true,
+	HelpMessage="Enter file path to create CSV report in",
+	ValueFromPipeline=$false)]
+    [ValidateScript({ Test-Path $_ -PathType Container  })]
+	$outputPath
+)
+
+#import SharePointPnPPowerShellOnline
+#import SharePointSDK
+
+
+    try
+    {
+
+    Import-Module SharePointPnPPowerShellOnline -ErrorAction Stop
+    Import-Module SharePointSDK -ErrorAction Stop
+
+    }
+    catch
+    {
+
+    
+    Start-Process -FilePath "powershell" -Verb runas -ArgumentList "Install-Module SharePointPnPPowerShellOnline -Force -AllowClobber;" -Wait 
+    Start-Process -FilePath "powershell" -Verb runas -ArgumentList "Install-Module SharePointSDK -Force -AllowClobber;" -Wait 
+    Import-Module SharePointPnPPowerShellOnline
+    Import-Module SharePointSDK 
+
+    }
+
+$spcred = Get-Credential
+
+$urls = @()
+
+$OD4BSites = @()
+
+
+Connect-PNPonline -Url "$($rootSite)" -Credentials $spcred 
+
+$urls = Get-PnPTenantSite -IncludeOneDriveSites  -Detailed  
+
+$allContentObjects = @()
+
+foreach($url in $urls)
+{
+
+
+if($url.Url -match "personal")
+{
+
+try
+{
+
+Connect-PNPonline -Url "$($url.Url)" -Credentials $spcred
+
+
+
+$allLists = Get-PnPList 
+
+foreach($list in $allLists)
+{
+
+
+try
+{
+
+$items = Get-SPListItem -Credential $spcred -IsSharePointOnlineSite $true -ListName "$($list.Title)" -SiteUrl "$($url.Url)" 
+
+}
+catch
+{
+
+Write-Warning -Message "Warning Access to $($list.Title) was denied. Files from this list will not be scanned"
+
+}
+
+foreach($listItem in $items)
+{
+
+$userName = $listItem.SharedWithUsers.LookupValue 
+$emailName = $listItem.SharedWithUsers.Email
+$tenantName = $spcred.UserName.Split('@')[1]
+
+if($userName -ne $null -and $emailName -notmatch $tenantName -and $userName -ne "Everyone except external users")
+{
+
+if($listItem.FileLeafRef.Contains('.'))
+{
+
+Write-Host "File $($listItem.FileLeafRef) shared with $username at $($listItem.FileRef)"
+
+}
+else
+{
+
+Write-Host "Folder $($listItem.FileLeafRef) shared with $username at $($listItem.FileRef)"
+
+}
+
+
+$object = New-Object –TypeName PSObject 
+$object | Add-Member –MemberType NoteProperty –Name Name –Value $listItem.FileLeafRef 
+
+if($emailName -ne "")
+{
+
+$object | Add-Member –MemberType NoteProperty –Name ExternalUser –Value " $emailName "
+}
+else
+{
+
+$object | Add-Member –MemberType NoteProperty –Name ExternalUser –Value " $username "
+}
+
+
+$object | Add-Member –MemberType NoteProperty –Name URL –Value $listItem.FileRef 
+
+
+
+
+if($object -ne $null)
+{
+    $OD4BSites += $object
+
+}
+#endNullCheck
+
+}
+#endcheck
+
+}
+#enditemsloop
+
+}
+#endlistsloop
+
+}
+catch
+{
+
+Write-Warning -Message "Warning Access to $($url.Url) was denied. Files from this site will not be scanned"
+
+}
+
+}
+
+
+}
+#endsitesloop
+
+$OD4Breport = $outputPath + "\OD4BReportExternalUsers.csv"
+
+if((Test-Path -Path "$OD4Breport"))
+{
+
+$OD4BSites | Export-Csv -Path "$OD4Breport" -Force -NoTypeInformation
+
+}
+else
+{
+
+New-Item -Path "$OD4Breport" -ItemType file
+$OD4BSites | Export-Csv -Path "$OD4Breport" -Force -NoTypeInformation
+}
+
+

--- a/scripts/Get-OD4BExternalUsers/README.md
+++ b/scripts/Get-OD4BExternalUsers/README.md
@@ -1,0 +1,68 @@
+# Microsoft FastTrack Open Source - Get-OD4BExternalUsers
+
+##Usage
+The purpose of this script is to search a tenant's OD4B sites for all files that are shared with external users. Once all of this data is found a csv report will be created.
+
+### Run
+
+1. Copy the script file "Get-OD4BExternalUsers.ps1" to a folder and open a PowerShell command window to that folder
+2. Execute the script using:
+
+`.\Get-OD4BExternalUser.ps1 -rootSite "https://myTenant.sharepoint.com/" -outputPath "c:\users\me\documents"'
+
+(You may be prompted to install the nuget provider and several other libraries. This is expected so the dependencies can be auto-installed.)
+
+3. Review the produced csv file
+
+
+|Option|Description|Default
+|----|--------------------------|--------------------------
+|rootSite|The SharePoint Online root site url|**required**
+|outputPath|The file path that the user wishes to contain the final report|**required**
+
+
+### External Dependencies
+
+SharePointPnPPowerShellOnline PowerShell Module
+SharePointSDK PowerShell Module
+
+## Applies To
+
+- SharePoint Online
+
+## Author
+
+|Author|Original Publish Date
+|----|--------------------------
+|Nicholas Switzer, Microsoft|May 22, 2018|
+
+## Issues
+
+Please report any issues you find to the [issues list](../../../../issues).
+
+## Support Statement
+
+The scripts, samples, and tools made available through the FastTrack Open Source initiative are provided as-is. These resources are developed in partnership with the community and do not represent official Microsoft software. As such, support is not available through premier or other official support channels. If you find an issue or have questions please reach out through the issues list and we'll do our best to assist, but there is no support SLA associated with these tools.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Legal Notices
+
+Microsoft and any contributors grant you a license to the Microsoft documentation and other content
+in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
+see the [LICENSE](https://github.com/Microsoft/FastTrack/blob/master/LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the
+[LICENSE-CODE](https://github.com/Microsoft/FastTrack/blob/master/LICENSE-CODE) file.
+
+Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
+may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
+The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
+Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+
+Privacy information can be found at https://privacy.microsoft.com/en-us/
+
+Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
+or trademarks, whether by implication, estoppel or otherwise.

--- a/scripts/get-teamsusage/Get-TeamsUsage.ps1
+++ b/scripts/get-teamsusage/Get-TeamsUsage.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 
 .SYNOPSIS
   Name: Get-TeamsUsage.ps1
@@ -139,11 +139,7 @@ process {
         $parameterset += $str
     }
     
-    #If the date is specified then add that to the parameters unless it is not supported
-    if ($date -and !($report -eq "MailboxUsage" -or $report -notlike "*Office365Activation*" -or $report -notlike "*getSkypeForBusinessOrganizerActivity*")) {
-        $str = "date='{0}'" -f $Date
-        $parameterset += $str
-    }
+ 
 
     #Trim a trailing comma off the ParameterSet if needed
     if ($parameterset) {


### PR DESCRIPTION
# Category
- [1] Bug fix
- [3] New script
- [ ] New sample


# What's in this Pull Request?
Added scripts for SPO/Teams management and removed unnecessary if statement in Teams Usage Report script

Get-OD4BExternalUsers - The purpose of this script is to search a tenant's OD4B sites for all files that are shared with external users. Once all of this data is found a csv report will be created.

Get-FullTeamsReport - The purpose of this script is to report all teams, channels, and users that exists in an environment.

Get-FullOwnerReport - This script looks for and reports all users and groups that have full control access for all sites and subsites in a user's tenant.
