### PR TITLE
Added parameter for Get-FullTeamsReport to grab all Unified Groups

### DIFF
--- a/scripts/Get-FullTeamsReport/Get-FullTeamsReport.ps1
+++ b/scripts/Get-FullTeamsReport/Get-FullTeamsReport.ps1
@@ -49,7 +49,7 @@ $creds = Get-Credential
 $Session365 = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $creds -Authentication Basic -AllowRedirection
 
 
-$allGroups = Invoke-Command -ScriptBlock {Get-UnifiedGroup} -Session $Session365 
+$allGroups = Invoke-Command -ScriptBlock {Get-UnifiedGroup -ResultSize Unlimited} -Session $Session365 
 
 Remove-PSSession -Session $Session365
 


### PR DESCRIPTION
# Category
- [1] Bug fix
- [ ] New script
- [ ] New sample

# What's in this Pull Request?
Added parameter -ResultSize Unlimited to ensure  Get-FullTeamsReport grabs every Unified group in a user's environment.


