### PR TITLE
Fix divide by zero error

### DIFF
--- a/scripts/Get-TeamsChannelUsersReport/Get-TeamsChannelUsersReport.ps1
+++ b/scripts/Get-TeamsChannelUsersReport/Get-TeamsChannelUsersReport.ps1
@@ -219,6 +219,9 @@ $ReportOutput = foreach ($group in $M365GroupsThatAreTeams) {
     } else {
         $totalChannelCount = $channelsList.count
     }
+    # if team only has a single channel, the above .count will retun a $null instead of 1 since it's not a collection, so need to ensure count is at least 1
+    # (could also fix by strongly-typing the get channel calls as collections so .count is always asking against a collection)
+    if (!$totalChannelCount -or $totalChannelCount -lt 1) {$totalChannelCount = 1}
     
     [PSCustomObject[]]$channelsReturn = foreach ($channel in $channelsList) {
 


### PR DESCRIPTION
# Category
- [X] Bug fix

# What's in this Pull Request?

Added protection for single-channel teams causing my code assumption for counting a collection to end up dividing by zero for progress bar


