### PR TITLE
Update Find-MailboxDelegates.ps1

### DIFF
--- a/scripts/Find-MailboxDelegates/Find-MailboxDelegates.ps1
+++ b/scripts/Find-MailboxDelegates/Find-MailboxDelegates.ps1
@@ -288,7 +288,9 @@ Begin{
             
                     If($gathercalendar -eq $true){
                         $Error.Clear()
-	                    $CalendarPermission = Get-MailboxFolderPermission -Identity ($Mailbox.alias + ':\Calendar') -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | ?{$_.User -notlike "Anonymous" -and $_.User -notlike "Default"} | Select User, AccessRights
+
+	                    $calFolder = Get-MailboxFolderStatistics -Identity $Mailbox.alias -FolderScope Calendar | Where-Object {$_.FolderType -eq 'Calendar' -and -not $_.Movable } | Select-Object Name, FolderId
+	                    $CalendarPermission = Get-MailboxFolderPermission -Identity ('{0}:{1}' -f $Mailbox.Alias, $calFolder.FolderId) -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | ?{$_.User -notlike "Anonymous" -and $_.User -notlike "Default"} | Select User, AccessRights
 	                    if (!$CalendarPermission){
                             $Calendar = (($Mailbox.PrimarySmtpAddress.ToString())+ ":\" + (Get-MailboxFolderStatistics -Identity $Mailbox.DistinguishedName -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | where-object {$_.FolderType -eq "Calendar"} | Select-Object -First 1).Name)
                             $CalendarPermission = Get-MailboxFolderPermission -Identity $Calendar -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | ?{$_.User -notlike "Anonymous" -and $_.User -notlike "Default"} | Select User, AccessRights

--- a/scripts/Find-MailboxDelegates/Find-MailboxDelegates.ps1
+++ b/scripts/Find-MailboxDelegates/Find-MailboxDelegates.ps1
@@ -291,10 +291,6 @@ Begin{
 
 	                    $calFolder = Get-MailboxFolderStatistics -Identity $Mailbox.alias -FolderScope Calendar | Where-Object {$_.FolderType -eq 'Calendar' -and -not $_.Movable } | Select-Object Name, FolderId
 	                    $CalendarPermission = Get-MailboxFolderPermission -Identity ('{0}:{1}' -f $Mailbox.Alias, $calFolder.FolderId) -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | ?{$_.User -notlike "Anonymous" -and $_.User -notlike "Default"} | Select User, AccessRights
-	                    if (!$CalendarPermission){
-                            $Calendar = (($Mailbox.PrimarySmtpAddress.ToString())+ ":\" + (Get-MailboxFolderStatistics -Identity $Mailbox.DistinguishedName -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | where-object {$_.FolderType -eq "Calendar"} | Select-Object -First 1).Name)
-                            $CalendarPermission = Get-MailboxFolderPermission -Identity $Calendar -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | ?{$_.User -notlike "Anonymous" -and $_.User -notlike "Default"} | Select User, AccessRights
-	                    }
             
                         If($CalendarPermission){
                             Foreach($perm in $CalendarPermission){


### PR DESCRIPTION
Update for localized calendar names

# Category
- [ ] Bug fix
- [ ] New script
- [ ] New sample

# Related Issues

Retrieving calendar permissions hard-coded looks at Calendar. Doest not work for localized calendar names.

# What's in this Pull Request?

Update to first determine the calendar name, then fetches the permissions using this name.


