### PR TITLE
Update Create-EngageCommunities.ps1

### DIFF
--- a/scripts/Create-EngageCommunities/Create-EngageCommunities.ps1
+++ b/scripts/Create-EngageCommunities/Create-EngageCommunities.ps1
@@ -116,6 +116,7 @@ function New-Community {
         # Check community creation status.
         # https://learn.microsoft.com/en-us/graph/api/engagementasyncoperation-get?view=graph-rest-beta
         Do{
+            # Check status too quickly and it'll fail. Adding 2 second sleep to account for timing.
             Start-Sleep -Seconds 2
             $operationInfo = Invoke-RestMethod -Uri $statusUri -Headers $headers -Method Get
             if ($operationInfo.status -eq "succeeded") {


### PR DESCRIPTION
Added comment around reason for 2 second sleep

# Category
- [x ] Bug fix


Adding a comment in the script to explain why the 2 second sleep exists right before the REST call to check creation status


