### PR TITLE
docs: clarify skill value vs built-in calendar event pattern for powerclaw skills

### DIFF
--- a/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/executive-radar.md
+++ b/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/executive-radar.md
@@ -26,6 +26,10 @@ It pulls together:
 
 The result is a short, scannable radar ordered by urgency, with a recommended next action for each item.
 
+> 💡 **Quick start — PowerClaw is already scanning:** The heartbeat already checks for urgent email, upcoming meetings, task drift, and follow-ups every 30 minutes, and a routine like **`[PowerClaw Routine] Morning Radar`** can make that even more focused.
+>
+> This skill adds the on-demand, deeper-triage version: ask what matters right now, get 🔴🟡🟢 prioritization plus recommended actions, and use PowerClaw’s memory to weigh who matters most and what commitments may be slipping.
+
 ## Why This Beats "Show Me My Unread Emails"
 
 A normal email or calendar assistant reports what exists. Executive Radar judges what matters.

--- a/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/meeting-copilot-loop.md
+++ b/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/meeting-copilot-loop.md
@@ -22,6 +22,10 @@ It supports three modes:
 
 This is where PowerClaw becomes more than “meeting summarization.” It connects **before**, **after**, and **what happened next** into one continuous operating loop.
 
+> 💡 **Quick start — already built in:** PowerClaw’s heartbeat already watches for meetings starting soon and can send a prep brief automatically, so you may not need any extra setup for the prep half.
+>
+> This skill adds the interactive, full-loop version: ask for prep on demand, recap a meeting after it ends, extract commitments, and push follow-through into the SharePoint task board instead of stopping at a one-time brief.
+
 ## Why This Beats Native M365 Copilot Recaps
 - **It remembers history** — prior commitments, unresolved issues, and relationship context can carry forward across recurring meetings.
 - **It works proactively** — PowerClaw’s heartbeat can brief the user automatically before a meeting starts, without being asked.

--- a/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/weekly-status-report.md
+++ b/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/weekly-status-report.md
@@ -35,6 +35,10 @@ The report is organized into:
 5. **Upcoming Priorities**
 6. **Follow-ups Needed**
 
+> 💡 **Quick start — no setup needed:** Add a recurring calendar event named **`[PowerClaw Routine] Weekly Status Report`** and PowerClaw can pick it up on heartbeat and generate the report automatically.
+>
+> This skill is the more interactive version: use it any time, tailor the report for your manager vs. leadership vs. project team, change the date range, skip or emphasize sections, and review the draft before anything gets sent.
+
 ## When to Use It
 
 Use this skill when you need to:


### PR DESCRIPTION
Each skill now acknowledges PowerClaw's zero-setup calendar event shortcut (e.g. [PowerClaw Routine] Weekly Status Report) and clearly states what the skill adds beyond it:

- Weekly Status Report: on-demand, custom audience, date range, review-before-send
- Meeting Copilot Loop: recap + commitment extraction + task board push
- Executive Radar: on-demand deep triage with prioritization and memory context




