### PR TITLE
Add copilot-studio-workflow skill plugin (v1.0.0)

### DIFF
--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/CHANGELOG.md
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the copilot-studio-workflow skill are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-04-10
+
+### Added
+- SKILL.md with full development workflow: pull → revert → edit → push → publish → test → commit
+- Prerequisites and first-time setup guidance with dependency tables and checklist
+- Platform gotchas covering initialization, packaging, development, and deployment
+- Best practices for agent architecture, YAML hygiene, testing, solution packaging, memory/state, and security
+- `scripts/cps-status.ps1` — project health check with dependency detection
+- `scripts/cps-revert.ps1` — safe workflow file revert after cloud pull
+- `scripts/cps-preflight.ps1` — pre-push hygiene checks
+- `scripts/cps-add-component.ps1` — add bot component to Power Platform solution
+- `reference/gotchas.md` — deep-dive platform gotchas
+- `reference/workflow-guide.md` — detailed workflow documentation
+- Plugin manifest (`plugin.json`) for GitHub Copilot CLI plugin install
+- Compatibility notes for GitHub Copilot CLI, Claude Code, VS Code Copilot, and Copilot Cloud Agent

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/README.md
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/README.md
@@ -1,0 +1,137 @@
+# copilot-studio-workflow
+
+A development workflow skill for building, syncing, packaging, and shipping Copilot Studio agents.
+
+## What this skill does
+- Teaches the proven **pull → revert → edit → push → publish → test → commit** loop
+- Captures platform gotchas around sync, solution packaging, variables, and flows
+- Ships helper PowerShell scripts for project status, workflow reverts, preflight checks, and solution component adds
+- Includes best practices for agent architecture, YAML hygiene, testing, memory, and security
+- Provides deeper reference docs for day-to-day development and production packaging
+
+## Install
+
+### From GitHub (recommended)
+
+Install directly from the FastTrack repository:
+
+```sh
+copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow
+```
+
+Update to the latest version:
+
+```sh
+copilot plugin update copilot-studio-workflow
+```
+
+### From the CLI (interactive)
+
+```text
+/plugin add
+```
+
+Then search for `copilot-studio-workflow`.
+
+### Manual — personal skill (all repos)
+
+Copy the inner skill folder to your personal skills directory.
+
+**Windows:**
+
+```powershell
+$src = "path\\to\\copilot-studio-workflow\\skills\\copilot-studio-workflow"
+Copy-Item -Recurse $src "$env:USERPROFILE\\.copilot\\skills\\copilot-studio-workflow"
+```
+
+**macOS / Linux:**
+
+```bash
+cp -r path/to/copilot-studio-workflow/skills/copilot-studio-workflow ~/.copilot/skills/
+```
+
+### Manual — project skill (single repo)
+
+Copy the inner skill folder into your repository.
+
+**Windows:**
+
+```powershell
+Copy-Item -Recurse .\skills\copilot-studio-workflow .\.github\skills\copilot-studio-workflow
+```
+
+**macOS / Linux:**
+
+```bash
+cp -r skills/copilot-studio-workflow .github/skills/copilot-studio-workflow
+```
+
+### Claude Code
+
+Copy the inner skill folder to your Claude skills directory:
+
+```bash
+cp -r skills/copilot-studio-workflow ~/.claude/skills/copilot-studio-workflow
+```
+
+## Prerequisites
+- Git
+- PowerShell (7+ recommended, 5.1 works on Windows)
+- `pac` CLI is optional but recommended for solution packaging
+
+## Compatibility
+
+| Tool | Install method |
+|---|---|
+| **GitHub Copilot CLI** | `copilot plugin install` or personal skill at `~/.copilot/skills/` |
+| **Claude Code** | Personal skill at `~/.claude/skills/` |
+| **VS Code Copilot** | Project skill at `.github/skills/` |
+| **Copilot Cloud Agent** | Project skill at `.github/skills/` |
+
+The `SKILL.md` format is an [open standard](https://github.com/agentskills/agentskills) supported across multiple AI coding tools.
+
+## What's included
+
+| File | Purpose |
+|---|---|
+| `plugin.json` | Plugin manifest for `copilot plugin install` |
+| `CHANGELOG.md` | Version history |
+| `skills/copilot-studio-workflow/SKILL.md` | Core skill instructions |
+| `skills/copilot-studio-workflow/scripts/cps-status.ps1` | Project health check |
+| `skills/copilot-studio-workflow/scripts/cps-revert.ps1` | Workflow file revert |
+| `skills/copilot-studio-workflow/scripts/cps-preflight.ps1` | Pre-push hygiene checks |
+| `skills/copilot-studio-workflow/scripts/cps-add-component.ps1` | Add component to solution |
+| `skills/copilot-studio-workflow/reference/gotchas.md` | Platform gotchas deep-dive |
+| `skills/copilot-studio-workflow/reference/workflow-guide.md` | Workflow documentation |
+
+## How to use
+
+After installing, the skill activates automatically when your prompts mention Copilot Studio, `.mcs.yml`, solution packaging, `pac` CLI, or related topics.
+
+Examples:
+- "Help me push these Copilot Studio YAML changes safely."
+- "How do I package this Copilot Studio agent for production?"
+- "Why did my pull dirty workflow JSON files?"
+- "Run a preflight check before I push."
+
+Force activation: include `/copilot-studio-workflow` in your prompt.
+
+## Versioning
+
+This plugin uses [Semantic Versioning](https://semver.org/). Check `CHANGELOG.md` for the full version history.
+
+To update:
+
+```sh
+copilot plugin update copilot-studio-workflow
+```
+
+## Contributing
+- Keep `SKILL.md` concise — it is loaded directly into context
+- Put detailed explanations in `reference/`
+- Keep scripts safe to run repeatedly
+- Bump the version in both `plugin.json` and `CHANGELOG.md` on every release
+- Test scripts: `powershell -NoProfile -File skills\\copilot-studio-workflow\\scripts\\<name>.ps1 -?`
+
+## License
+MIT

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/plugin.json
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "copilot-studio-workflow",
+  "description": "Development workflow skill for building, syncing, packaging, and shipping Copilot Studio agents. Encodes the proven pull-revert-push-publish loop, platform gotchas, best practices, and helper scripts.",
+  "version": "1.0.0",
+  "author": {
+    "name": "FastTrack Team",
+    "url": "https://github.com/microsoft/FastTrack"
+  },
+  "homepage": "https://github.com/microsoft/FastTrack/tree/master/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow",
+  "repository": "https://github.com/microsoft/FastTrack.git",
+  "license": "MIT",
+  "keywords": [
+    "copilot-studio",
+    "power-platform",
+    "agent-development",
+    "yaml-workflow",
+    "pac-cli"
+  ],
+  "category": "development",
+  "tags": [
+    "copilot-studio",
+    "mcs",
+    "power-platform",
+    "agent",
+    "yaml",
+    "pac"
+  ],
+  "skills": "skills/"
+}

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/SKILL.md
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: copilot-studio-workflow
+description: >
+  Development workflow for building, syncing, packaging, and shipping Copilot Studio agents.
+  Use this skill when working with Copilot Studio YAML files (agent.mcs.yml, topics, actions, variables),
+  when pulling or pushing agent changes, when packaging solutions for distribution,
+  or when troubleshooting common Copilot Studio platform issues.
+  Triggers on: Copilot Studio, MCS, agent.mcs.yml, .mcs.yml files, pac CLI, Power Platform solution,
+  pull from cloud, push to cloud, publish agent, solution packaging, heartbeat flow, Power Automate flows.
+allowed-tools: shell
+license: MIT
+---
+
+# Copilot Studio Workflow
+
+## Overview
+- Copilot Studio agents are YAML-first assets (`.mcs.yml`) that sync between a local repo and the cloud.
+- Treat the **development/demo** environment as the real working environment and the **production** environment as a packaged distribution target.
+- Keep generic placeholder URLs in git (for example `contoso.sharepoint.com`); real demo URLs belong only in the live environment.
+- Follow the proven loop: **pull → revert env-specific files → edit → push → publish → test → commit**.
+
+## Prerequisites & First-Time Setup
+
+When starting work on a Copilot Studio project for the first time, verify the following tools are installed and configured. Run `.\scripts\cps-status.ps1` for a quick health check.
+
+### Required
+| Tool | Purpose | Install |
+|---|---|---|
+| **Git** | Source control for agent YAML files | [git-scm.com](https://git-scm.com) |
+| **VS Code** | Editor for YAML and local development | [code.visualstudio.com](https://code.visualstudio.com) |
+| **Copilot Studio VS Code Extension** | Pull/push agent YAML between local files and cloud environments | [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=microsoft-IsvExpTools.microsoft-copilot-studio) |
+| **Power Platform environment** | A Copilot Studio-enabled environment to develop in | [Power Platform admin center](https://admin.powerplatform.microsoft.com) |
+
+### Recommended
+| Tool | Purpose | Install |
+|---|---|---|
+| **Power Platform CLI (`pac`)** | Solution export/import, component management | [Microsoft docs](https://learn.microsoft.com/en-us/power-platform/developer/cli/introduction) |
+| **Copilot Studio Skills Plugin** | Additional CPS authoring tools in Copilot CLI | `/plugin add` → search for Copilot Studio |
+| **PowerShell 7+** | Cross-platform script execution | [github.com/PowerShell](https://github.com/PowerShell/PowerShell) |
+
+### First session checklist
+1. Run `.\scripts\cps-status.ps1` to detect the project and check tool availability.
+2. If no `agent.mcs.yml` exists, clone an agent from the cloud using the VS Code extension or Copilot Studio manage flow.
+3. If `pac` CLI is needed for solution packaging, authenticate: `pac auth create --environment <URL>`.
+4. Verify the VS Code Copilot Studio extension can connect to your environment (open the agent folder, **Sync → Pull**).
+
+## Development Loop
+1. **Pull from cloud** using the VS Code Copilot Studio extension (**Sync → Pull**) or the Copilot Studio manage flow.
+2. **Revert workflow files immediately.** Cloud pulls often inject environment-specific URLs into `workflows/*.json` and `settings.mcs.yml`. Run `.\scripts\cps-revert.ps1` (or `git checkout -- **/workflows/ **/settings.mcs.yml`) before reviewing diffs.
+3. **Edit locally** in `.mcs.yml` files: topics, actions, variables, instructions, triggers, and agent settings.
+4. **Push to cloud** with the VS Code extension (**Sync → Push**) or manage-agent tooling.
+5. **Publish** in Copilot Studio so the draft becomes live.
+6. **Test in the real channel** (Teams or Microsoft 365 Copilot). The test pane is useful for quick checks, but it is not representative of production behavior.
+7. **Commit to git** only after the live agent behaves correctly and workflow files are clean.
+
+## Solution Packaging
+- Use `pac solution export` to export the solution from the demo environment.
+- The solution should include the agent, Power Automate flows, and connection references.
+- For production distribution: **export → unpack → scrub environment URLs → repack as a clean zip**.
+- Teams import the solution zip, reconnect dependencies, re-enable flows, and follow the setup guide.
+
+## Adding New Components
+- A VS Code push creates Dataverse components, but it does **not** add new bot components to the Power Platform solution.
+- Add them explicitly with `pac solution add-solution-component -sn <SOLUTION> -c <GUID> -ct botcomponent`.
+- Find the component GUID with `pac org fetch` against `botcomponent` records.
+- Use `.\scripts\cps-add-component.ps1` for guided lookup and add-to-solution flow.
+
+## Platform Gotchas
+
+### Initialization
+- `OnConversationStart` does **not** fire in Microsoft 365 Copilot and usually fires only once in Teams. Use `OnActivity(type: Message)` plus an `IsBlank()` just-in-time guard instead.
+- Copilot Studio does not stream partial messages; the platform batches output.
+
+### Packaging
+- VS Code push ≠ solution membership. New components must be added to the solution separately.
+- Global variables need YAML definitions in `variables/` or solution imports can fail or create broken references.
+- Solution import deactivates Power Automate flows; always re-enable them after import.
+- Cloud pull brings environment-specific URLs into workflow files; always revert them before commit.
+- Extension push/pull is all-or-nothing; there is no selective sync.
+
+### Development
+- `ConcurrencyVersionMismatch` on push usually means someone changed the cloud copy. Pull again before pushing.
+- The Copilot Studio test pane does not match real channel behavior; validate in Teams or Microsoft 365 Copilot.
+- Housekeeping flow push error `0x80040216` is a known benign issue.
+
+### Deployment
+- Export scripts capture the state that exists at export time. Do not run packaging scripts after a YAML push unless you intend to rebuild from that exact state.
+- `pac` component type codes are brittle across environments; prefer the name-based `-ct botcomponent` pattern in your workflow.
+
+## Best Practices
+
+### Agent Architecture
+- Use a **constitution file pattern** (markdown files in SharePoint or OneDrive) for dynamic instructions — edit behavior without YAML surgery.
+- Keep agent instructions concise in `agent.mcs.yml`; load detailed context via global variables populated at runtime by a Power Automate flow.
+- Use `OnActivity(type: Message)` with an `IsBlank()` JIT guard for reliable context initialization across all channels (Teams, M365 Copilot).
+
+### YAML Hygiene
+- One topic per file. Name files to match the topic's purpose (for example `Greeting.mcs.yml`, `EscalateToHuman.mcs.yml`).
+- Define all global variables explicitly in `variables/` with YAML files — never rely on UI-only definitions.
+- Use descriptive `schemaName` values — they appear in Dataverse queries and logs.
+
+### Testing
+- Always test in the real channel (Teams or M365 Copilot), not just the test pane.
+- MCP tools, connectors, and OAuth flows only work in published agents on real channels.
+- Use calendar-driven routines (for example `[AgentName Routine] Weekly Review`) for testing autonomous behaviors.
+
+### Solution Packaging
+- Establish a URL placeholder convention from day one (for example `contoso.sharepoint.com`). Retrofitting is painful.
+- Always revert workflow files after cloud pulls — one missed revert leaks production URLs into source control.
+- After pushing new components via VS Code, explicitly add them to the solution with `pac solution add-solution-component`.
+- Re-enable all Power Automate flows after every solution import — imports deactivate them silently.
+
+### Memory & State (for agents with persistent memory)
+- Use SharePoint lists for structured memory (facts, preferences, tasks) and markdown files for narrative or journal memory.
+- Design memory with expiration — stale facts degrade agent quality over time.
+- Keep memory scoped (for example `preference:timezone`, `person:manager`) for efficient retrieval.
+
+### Security & Governance
+- Review all MCP tools and connectors before enabling — each one expands the agent's access surface.
+- Use the `KillSwitch` pattern (a config flag that halts autonomous behavior) for any agent that acts without user prompting.
+- Audit agent activity through logging lists or flows — autonomous agents need observability.
+
+## Included Scripts
+- `scripts/cps-status.ps1` — quick project health check: agent info, counts, git state, dirty workflow files, and `pac` availability.
+- `scripts/cps-revert.ps1` — run after every cloud pull to revert `workflows/*.json` and `settings.mcs.yml` back to the repo-safe version.
+- `scripts/cps-preflight.ps1` — run before push to check workflow hygiene, git state, and missing global variable definitions.
+- `scripts/cps-add-component.ps1` — locate a bot component by schema pattern and add it to the Power Platform solution.
+
+## Quick Reference
+| Task | Command / Path |
+| --- | --- |
+| First-time setup | `.\scripts\cps-status.ps1` |
+| Install pac CLI | `winget install Microsoft.PowerPlatformCLI` (Windows) or `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` |
+| Authenticate pac | `pac auth create --environment <URL>` |
+| Clone agent from cloud | VS Code extension → open folder → Sync → Pull |
+| Pull from cloud | VS Code Copilot Studio extension → **Sync → Pull** |
+| Push to cloud | VS Code Copilot Studio extension → **Sync → Push** |
+| Revert workflows | `.\scripts\cps-revert.ps1` or `git checkout -- **/workflows/ **/settings.mcs.yml` |
+| Publish | Copilot Studio → **Publish** |
+| Pre-push check | `.\scripts\cps-preflight.ps1` |
+| Add component | `.\scripts\cps-add-component.ps1 -SolutionName "MySolution" -SchemaPattern "my.topic.Name"` |
+| Project status | `.\scripts\cps-status.ps1` |
+| Emergency stop | Set `KillSwitch = true` in the config list |
+
+## References
+- Deep dive: `reference/gotchas.md`
+- Workflow details: `reference/workflow-guide.md`
+
+
+

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/reference/gotchas.md
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/reference/gotchas.md
@@ -1,0 +1,108 @@
+# Copilot Studio Platform Gotchas
+
+This reference captures recurring issues that show up when teams build Copilot Studio agents from YAML, sync with the VS Code extension, and package solutions for customers.
+
+## Initialization
+
+### `OnConversationStart` is not a reliable initialization hook
+**Symptom:** Initialization logic works in the Copilot Studio test pane or in Teams once, but not in Microsoft 365 Copilot or later turns.
+
+**Why it happens:** `OnConversationStart` is channel-sensitive. In Microsoft 365 Copilot it often does not fire at all, and in Teams it usually fires only once for a conversation.
+
+**Proven workaround:** Move initialization into an `OnActivity` trigger for `Message` activity and guard it with `IsBlank()` checks. That gives you just-in-time initialization that runs only when data is missing.
+
+**Typical pattern:**
+- Trigger on `Message`
+- Check if a critical global variable is blank
+- If blank, populate profile, glossary, or configuration variables
+- Continue to the user-facing topic
+
+### There is no true message streaming
+**Symptom:** Multiple `SendMessage` nodes look like they should stream progress updates, but the user receives a single batched response.
+
+**Why it happens:** Copilot Studio buffers output before returning it to the channel.
+
+**Workaround:** Design messages as complete, self-contained responses. If you need visible phases, use explicit “working / done” mechanics through external channels rather than assuming in-chat streaming.
+
+## Packaging
+
+### VS Code push creates Dataverse artifacts but not solution membership
+**Symptom:** A new topic or component works in the demo environment, but it is missing from exported solutions.
+
+**Why it happens:** Syncing YAML to the cloud creates the Dataverse component, but it does not automatically add that component to the Power Platform solution.
+
+**Workaround:** Add every new bot component explicitly with `pac solution add-solution-component ... -ct botcomponent`. The `cps-add-component.ps1` helper exists for exactly this step.
+
+### Global variables must have YAML definitions
+**Symptom:** The agent imports poorly, variables are missing, or topics fail at runtime after solution import.
+
+**Why it happens:** A variable referenced in `agent.mcs.yml` is not enough. The corresponding variable definition in `variables/*.mcs.yml` must exist so the solution contains the full definition.
+
+**Workaround:** Treat `variables/` as required source of truth. Run `cps-preflight.ps1` before push and before packaging.
+
+### Cloud pulls leak environment-specific URLs into source control
+**Symptom:** After a pull, unrelated diffs appear under `workflows/*.json` or `settings.mcs.yml`.
+
+**Why it happens:** The extension downloads live environment values, including real SharePoint URLs, flow endpoints, and environment-specific settings.
+
+**Workaround:** Revert those files immediately after every pull unless you intentionally changed them. The repository should keep generic placeholder values.
+
+### Solution import deactivates Power Automate flows
+**Symptom:** A customer imports the solution successfully, but flows never fire.
+
+**Why it happens:** Imported flows are usually disabled by default.
+
+**Workaround:** The post-import checklist must include reconnecting connections and re-enabling all flows.
+
+### Push/pull is all-or-nothing
+**Symptom:** You want to sync only one topic or one action, but the extension wants to move the whole agent.
+
+**Why it happens:** The current sync model is agent-wide.
+
+**Workaround:** Coordinate changes, pull before push, and avoid parallel edits in the same environment.
+
+## Development
+
+### `ConcurrencyVersionMismatch` means your local copy is stale
+**Symptom:** Push fails even though the YAML looks valid.
+
+**Why it happens:** Someone or something updated the cloud copy after your last pull.
+
+**Workaround:** Pull again, revert environment-specific workflow files, re-apply your local changes if needed, then push.
+
+### The test pane is not the real product
+**Symptom:** Behavior in the test pane differs from Teams or Microsoft 365 Copilot.
+
+**Why it happens:** Authentication, channel lifecycle, activity model, and trigger behavior differ between the test pane and production channels.
+
+**Workaround:** Use the test pane for quick iteration only. Final validation must happen in Teams or Microsoft 365 Copilot.
+
+### Housekeeping flow error `0x80040216` is usually benign
+**Symptom:** Push reports a housekeeping flow error even though the agent works.
+
+**Why it happens:** The platform sometimes throws a noisy error during housekeeping flow sync.
+
+**Workaround:** Confirm whether the functional assets actually synced. If the agent behaves correctly, treat the error as informational unless you see a real missing component.
+
+## Deployment
+
+### Export scripts capture the state that exists at export time
+**Symptom:** The packaged zip does not match the YAML you expected.
+
+**Why it happens:** Exporting after an unintended push captures whatever is in the demo environment at that moment.
+
+**Workaround:** Be deliberate about sequence. For packaging, know whether you are exporting the last published demo state or a freshly pushed state.
+
+### Prefer `-ct botcomponent` over brittle numeric component type codes
+**Symptom:** Script works in one environment but fails or becomes unclear in another.
+
+**Why it happens:** Numeric component-type workflows are harder to maintain and easier to misread.
+
+**Workaround:** Use the name-based pattern in your scripted workflow and keep the GUID lookup separate from the add-to-solution step.
+
+## Operational Tips
+- Pull before every push.
+- Revert workflow JSON and `settings.mcs.yml` after every pull.
+- Publish after every meaningful cloud change.
+- Test in the real channel, not only the test pane.
+- Before packaging, verify that every required component is both in Dataverse and in the solution.

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/reference/workflow-guide.md
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/reference/workflow-guide.md
@@ -1,0 +1,111 @@
+# Copilot Studio Workflow Guide
+
+## Why this workflow exists
+Copilot Studio agent projects sit in an awkward but workable middle ground:
+- The source of truth for agent logic is YAML in git.
+- The runtime source of truth is the cloud environment.
+- Solution packaging is what deployment teams actually import into production.
+
+A reliable workflow has to keep those three views aligned.
+
+## The URL translation problem
+A recurring pain point is URL drift across environments.
+
+### Repository state
+The repo should store neutral placeholders such as `https://contoso.sharepoint.com/sites/...` so the project can be shared safely and reused.
+
+### Demo environment state
+The real development or demo environment contains actual URLs, real flow connection references, and environment-specific settings. Pulling from the cloud brings those values back into local files.
+
+### Production environment state
+Production imports produce yet another set of URLs, connections, and environment bindings.
+
+### Practical rule
+Never treat pulled workflow JSON as repo-safe by default. Revert `workflows/*.json` and `settings.mcs.yml` after pull unless your explicit goal is to inspect those live values.
+
+## Default day-to-day workflow
+1. Pull from cloud.
+2. Revert workflow files and `settings.mcs.yml`.
+3. Edit YAML locally.
+4. Push to cloud.
+5. Publish.
+6. Test in Teams or Microsoft 365 Copilot.
+7. Commit only the intentional source changes.
+
+## Workflow variations
+
+### 1. YAML-only change
+Use this for topics, actions, triggers, variables, or agent instructions.
+- Pull
+- Revert workflow files
+- Edit YAML
+- Push
+- Publish
+- Test
+- Commit
+
+### 2. Flow change in Power Automate
+Use this when a flow was edited directly in the environment.
+- Pull to capture the new flow-backed artifacts
+- Immediately review whether workflow JSON contains live URLs you do not want in git
+- Revert unsafe files or scrub placeholders before commit
+- Validate the agent still calls the flow correctly
+- Publish if agent-side assets changed
+
+### 3. Rebuild production zip
+Use this when you need a fresh distributable solution.
+- Confirm the demo environment is exactly the version you want to ship
+- Export the solution with `pac solution export`
+- Unpack it if your process scrubs or patches artifacts
+- Remove environment-specific URLs and anything production-specific
+- Repack to a clean zip
+- Update the production setup guide if connection steps changed
+
+### 4. Add component to solution
+Use this after pushing a brand-new topic, action, or other bot component.
+- Push YAML so the component exists in Dataverse
+- Run `cps-add-component.ps1 -SolutionName ... -SchemaPattern ...`
+- Confirm the component appears in the solution
+- Re-export if you are preparing a production package
+
+### 5. Remove component
+Use this carefully because deletion order matters.
+- Remove or detach references in YAML first
+- Push and validate the agent
+- Remove the component from the solution if needed
+- Re-export the solution to confirm the package is clean
+
+## Setting up a new agent from scratch
+1. Create the Copilot Studio agent and establish the local YAML project structure.
+2. Decide the solution name early and keep it stable.
+3. Create placeholder-safe configuration values for anything environment-specific.
+4. Establish the script habit from day one:
+   - `cps-status.ps1` to understand the project
+   - `cps-revert.ps1` after pulls
+   - `cps-preflight.ps1` before pushes
+5. Define every global variable in `variables/` as soon as it exists.
+6. Document which flows must be re-enabled after import.
+7. Test real-channel behavior before calling the workflow stable.
+
+## Team collaboration tips
+
+### Avoid overlapping pushes
+The extension sync model is coarse. Multiple developers editing the same cloud agent without coordination almost guarantees `ConcurrencyVersionMismatch` or accidental overwrite.
+
+### Use pull-first discipline
+Before any push, pull first. Even if no conflict is obvious, this reduces surprise drift.
+
+### Separate repo-safe and environment-safe changes
+A change can be correct in the demo environment and still be wrong for git if it hard-codes a live URL.
+
+### Keep packaging responsibilities explicit
+Not every developer needs to export production zips, but someone must own solution membership, connection references, and post-import instructions.
+
+### Publish is part of done
+A pushed draft is not finished work. The workflow is only complete after publish plus real-channel validation.
+
+## Suggested working agreements
+- No push without a fresh pull.
+- No commit with dirty `workflows/*.json` unless intentionally reviewed.
+- No package export without confirming required components are in the solution.
+- No release sign-off without Teams or Microsoft 365 Copilot validation.

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-add-component.ps1
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-add-component.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SolutionName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SchemaPattern
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Require-Pac {
+    try {
+        $version = (& pac --version 2>$null | Select-Object -First 1)
+        if ([string]::IsNullOrWhiteSpace($version)) {
+            throw 'pac CLI returned no version information.'
+        }
+
+        Write-Host ("Using pac CLI {0}" -f $version) -ForegroundColor Green
+    }
+    catch {
+        throw 'pac CLI is required. Install it and ensure `pac --version` succeeds.'
+    }
+}
+
+function Parse-FetchOutput {
+    param([string[]]$Lines)
+
+    $results = @()
+    foreach ($line in $Lines) {
+        if ($line -match '^[\s\-]+$') { continue }
+        if ($line -match 'botcomponentid' -and $line -match 'schemaname') { continue }
+        if ($line -match '(?<Id>[0-9a-fA-F-]{36}).*?(?<Schema>auto_[A-Za-z0-9_\.\-]+|[A-Za-z0-9_\.\-]+)') {
+            $results += [pscustomobject]@{
+                Id = $Matches['Id']
+                SchemaName = $Matches['Schema']
+                Raw = $line.Trim()
+            }
+        }
+    }
+
+    return $results | Sort-Object SchemaName -Unique
+}
+
+try {
+    Require-Pac
+
+    $escapedPattern = [System.Security.SecurityElement]::Escape($SchemaPattern)
+    $fetchXml = @"
+<fetch>
+  <entity name='botcomponent'>
+    <attribute name='botcomponentid' />
+    <attribute name='schemaname' />
+    <attribute name='name' />
+    <filter>
+      <condition attribute='schemaname' operator='like' value='%$escapedPattern%' />
+    </filter>
+  </entity>
+</fetch>
+"@
+
+    Write-Host ("Searching botcomponents matching '{0}'..." -f $SchemaPattern) -ForegroundColor Cyan
+    $fetchOutput = @(& pac org fetch -x $fetchXml 2>&1)
+    $matches = @(Parse-FetchOutput -Lines $fetchOutput)
+
+    if ($matches.Count -eq 0) {
+        Write-Host 'No matching botcomponents found.' -ForegroundColor Red
+        Write-Host 'Suggestions:' -ForegroundColor Yellow
+        Write-Host '  - Check your pac auth connection and environment'
+        Write-Host '  - Try a broader schema pattern'
+        Write-Host '  - Verify the component was created by pushing from VS Code'
+        exit 1
+    }
+
+    if ($matches.Count -gt 1) {
+        Write-Host 'Multiple matching botcomponents found. Be more specific.' -ForegroundColor Yellow
+        $matches | ForEach-Object { Write-Host ("  - {0}  [{1}]" -f $_.SchemaName, $_.Id) }
+        exit 1
+    }
+
+    $component = $matches[0]
+    Write-Host ("Adding {0} to solution {1}..." -f $component.SchemaName, $SolutionName) -ForegroundColor Cyan
+    $addOutput = @(& pac solution add-solution-component -sn $SolutionName -c $component.Id -ct botcomponent 2>&1)
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host 'Failed to add solution component.' -ForegroundColor Red
+        $addOutput | ForEach-Object { Write-Host $_ }
+        exit 1
+    }
+
+    Write-Host ("Added {0} [{1}] to solution {2}." -f $component.SchemaName, $component.Id, $SolutionName) -ForegroundColor Green
+}
+catch {
+    Write-Host ("Error: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    exit 1
+}

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-preflight.ps1
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-preflight.ps1
@@ -1,0 +1,117 @@
+[CmdletBinding()]
+param(
+    [string]$Path = (Get-Location).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-AgentFile {
+    param([string]$StartPath)
+
+    $resolved = (Resolve-Path -LiteralPath $StartPath).Path
+    Get-ChildItem -Path $resolved -Recurse -File -Filter 'agent.mcs.yml' -Depth 6 -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '[\\/]\.git[\\/]' -and $_.FullName -notmatch '[\\/]node_modules[\\/]' } |
+        Sort-Object FullName |
+        Select-Object -First 1
+}
+
+function Write-Check {
+    param(
+        [bool]$Passed,
+        [string]$SuccessMessage,
+        [string]$FailureMessage
+    )
+
+    if ($Passed) {
+        Write-Host ("✅ {0}" -f $SuccessMessage) -ForegroundColor Green
+    }
+    else {
+        Write-Host ("⚠️  {0}" -f $FailureMessage) -ForegroundColor Yellow
+    }
+}
+
+try {
+    $allPassed = $true
+    $agentFile = Find-AgentFile -StartPath $Path
+    $agentExists = $null -ne $agentFile
+    Write-Check -Passed $agentExists -SuccessMessage ("Found agent file: {0}" -f $agentFile.FullName) -FailureMessage 'No agent.mcs.yml found.'
+    if (-not $agentExists) {
+        exit 1
+    }
+
+    $agentRoot = Split-Path -Parent $agentFile.FullName
+    $repoRoot = $null
+    try {
+        $repoRoot = (& git -C $agentRoot rev-parse --show-toplevel 2>$null).Trim()
+    }
+    catch {
+        $repoRoot = $null
+    }
+
+    if ($repoRoot) {
+        $statusLines = @(& git -C $repoRoot status --porcelain 2>$null)
+        $dirtyWorkflowFiles = @($statusLines |
+            ForEach-Object { if ($_ -match '^..\s+(?<Path>.+)$') { $Matches['Path'].Trim() } } |
+            Where-Object { $_ -and ($_ -match '(^|[\\/])workflows[\\/].+\.json$' -or $_ -match '(^|[\\/])settings\.mcs\.yml$') })
+
+        $workflowClean = $dirtyWorkflowFiles.Count -eq 0
+        Write-Check -Passed $workflowClean -SuccessMessage 'Workflow files are clean.' -FailureMessage ("Environment-specific workflow files are dirty: {0}" -f ($dirtyWorkflowFiles -join ', '))
+        if (-not $workflowClean) { $allPassed = $false }
+
+        $hasUncommittedChanges = $statusLines.Count -gt 0
+        Write-Check -Passed (-not $hasUncommittedChanges) -SuccessMessage 'Git working tree is clean.' -FailureMessage ("Git working tree has {0} modified item(s)." -f $statusLines.Count)
+        if ($hasUncommittedChanges) { $allPassed = $false }
+    }
+    else {
+        Write-Check -Passed $false -SuccessMessage '' -FailureMessage 'Git repository not detected.'
+        $allPassed = $false
+    }
+
+    $agentContent = Get-Content -LiteralPath $agentFile.FullName -Raw
+    $variableReferences = [regex]::Matches($agentContent, '\{Global\.([A-Za-z0-9_]+)\}') |
+        ForEach-Object { $_.Groups[1].Value } |
+        Sort-Object -Unique
+
+    $variablesPath = Join-Path $agentRoot 'variables'
+    $definedNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    if (Test-Path -LiteralPath $variablesPath) {
+        foreach ($variableFile in Get-ChildItem -Path $variablesPath -Recurse -File -Filter '*.mcs.yml' -ErrorAction SilentlyContinue) {
+            [void]$definedNames.Add([System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($variableFile.Name)))
+            $nameMatch = Get-Content -LiteralPath $variableFile.FullName | Select-String -Pattern '^\s*name\s*:\s*"?(?<Value>.+?)"?\s*$' | Select-Object -First 1
+            if ($nameMatch) {
+                [void]$definedNames.Add($nameMatch.Matches[0].Groups['Value'].Value.Trim())
+            }
+        }
+    }
+
+    $missingVariables = @()
+    foreach ($reference in $variableReferences) {
+        if (-not $definedNames.Contains($reference)) {
+            $missingVariables += $reference
+        }
+    }
+
+    $variablesOk = $missingVariables.Count -eq 0
+    if ($variableReferences.Count -eq 0) {
+        Write-Check -Passed $true -SuccessMessage 'No {Global.*} references found in agent.mcs.yml.' -FailureMessage ''
+    }
+    else {
+        Write-Check -Passed $variablesOk -SuccessMessage 'All referenced global variables have YAML definitions.' -FailureMessage ("Missing variable definitions: {0}" -f ($missingVariables -join ', '))
+        if (-not $variablesOk) { $allPassed = $false }
+    }
+
+    if ($allPassed) {
+        Write-Host ''
+        Write-Host 'Preflight passed.' -ForegroundColor Green
+        exit 0
+    }
+
+    Write-Host ''
+    Write-Host 'Preflight completed with warnings.' -ForegroundColor Yellow
+    exit 1
+}
+catch {
+    Write-Host ("Error: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    exit 1
+}

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-revert.ps1
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-revert.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [string]$Path = (Get-Location).Path,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-AgentFile {
+    param([string]$StartPath)
+
+    $resolved = (Resolve-Path -LiteralPath $StartPath).Path
+    Get-ChildItem -Path $resolved -Recurse -File -Filter 'agent.mcs.yml' -Depth 6 -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '[\\/]\.git[\\/]' -and $_.FullName -notmatch '[\\/]node_modules[\\/]' } |
+        Sort-Object FullName |
+        Select-Object -First 1
+}
+
+try {
+    $agentFile = Find-AgentFile -StartPath $Path
+    if (-not $agentFile) {
+        throw "No agent.mcs.yml file found within 6 levels of '$Path'."
+    }
+
+    $agentRoot = Split-Path -Parent $agentFile.FullName
+    $repoRoot = (& git -C $agentRoot rev-parse --show-toplevel 2>$null).Trim()
+    if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+        throw 'Git repository not detected.'
+    }
+
+    $modifiedFiles = @(& git -C $repoRoot diff --name-only 2>$null)
+    $targets = @($modifiedFiles | Where-Object {
+        $_ -and ($_ -match '(^|[\\/])workflows[\\/].+\.json$' -or $_ -match '(^|[\\/])settings\.mcs\.yml$')
+    })
+
+    if ($targets.Count -eq 0) {
+        Write-Host 'No modified workflow or settings files found.' -ForegroundColor Green
+        exit 0
+    }
+
+    if ($DryRun) {
+        Write-Host 'Files that would be reverted:' -ForegroundColor Yellow
+        $targets | ForEach-Object { Write-Host ("  - {0}" -f $_) }
+        exit 0
+    }
+
+    foreach ($target in $targets) {
+        & git -C $repoRoot checkout -- $target | Out-Null
+        Write-Host ("Reverted {0}" -f $target) -ForegroundColor Green
+    }
+
+    Write-Host ("Reverted {0} file(s)." -f $targets.Count) -ForegroundColor Green
+}
+catch {
+    Write-Host ("Error: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    exit 1
+}

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-status.ps1
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/scripts/cps-status.ps1
@@ -1,0 +1,196 @@
+[CmdletBinding()]
+param(
+    [string]$Path = (Get-Location).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Section {
+    param([string]$Title)
+    Write-Host ""
+    Write-Host "== $Title ==" -ForegroundColor Cyan
+}
+
+function Find-AgentFile {
+    param([string]$StartPath)
+
+    $resolved = (Resolve-Path -LiteralPath $StartPath).Path
+    Get-ChildItem -Path $resolved -Recurse -File -Filter 'agent.mcs.yml' -Depth 6 -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '[\\/]\.git[\\/]' -and $_.FullName -notmatch '[\\/]node_modules[\\/]' } |
+        Sort-Object FullName |
+        Select-Object -First 1
+}
+
+function Get-AgentName {
+    param([string]$AgentFile)
+
+    $content = Get-Content -LiteralPath $AgentFile
+    $displayMatch = $content | Select-String -Pattern '^\s*displayName\s*:\s*"?(?<Value>.+?)"?\s*$' | Select-Object -First 1
+    if ($displayMatch) {
+        return $displayMatch.Matches[0].Groups['Value'].Value.Trim()
+    }
+
+    $nameMatch = $content | Select-String -Pattern '^\s*name\s*:\s*"?(?<Value>.+?)"?\s*$' | Select-Object -First 1
+    if ($nameMatch) {
+        return $nameMatch.Matches[0].Groups['Value'].Value.Trim()
+    }
+
+    return '(name not found)'
+}
+
+function Get-Count {
+    param(
+        [string]$Root,
+        [string]$RelativePath,
+        [string]$Filter
+    )
+
+    $target = Join-Path $Root $RelativePath
+    if (-not (Test-Path -LiteralPath $target)) {
+        return 0
+    }
+
+    return (Get-ChildItem -Path $target -Recurse -File -Filter $Filter -ErrorAction SilentlyContinue).Count
+}
+
+try {
+    $agentFile = Find-AgentFile -StartPath $Path
+    if (-not $agentFile) {
+        throw "No agent.mcs.yml file found within 6 levels of '$Path'."
+    }
+
+    $agentRoot = Split-Path -Parent $agentFile.FullName
+    $agentName = Get-AgentName -AgentFile $agentFile.FullName
+    $topicCount = Get-Count -Root $agentRoot -RelativePath 'topics' -Filter '*.mcs.yml'
+    $actionCount = Get-Count -Root $agentRoot -RelativePath 'actions' -Filter '*.mcs.yml'
+    $variableCount = Get-Count -Root $agentRoot -RelativePath 'variables' -Filter '*.mcs.yml'
+    $workflowCount = Get-Count -Root $agentRoot -RelativePath 'workflows' -Filter '*.json'
+
+    $repoRoot = $null
+    try {
+        $repoRoot = (& git -C $agentRoot rev-parse --show-toplevel 2>$null).Trim()
+    }
+    catch {
+        $repoRoot = $null
+    }
+
+    $gitStatus = @()
+    $dirtyWorkflowFiles = @()
+    if ($repoRoot) {
+        $gitStatus = @(& git -C $repoRoot status --porcelain 2>$null)
+        $dirtyWorkflowFiles = @($gitStatus |
+            ForEach-Object { if ($_ -match '^..\s+(?<Path>.+)$') { $Matches['Path'].Trim() } } |
+            Where-Object { $_ -and ($_ -match '(^|[\\/])workflows[\\/].+\.json$' -or $_ -match '(^|[\\/])settings\.mcs\.yml$') })
+    }
+
+    $pacVersion = $null
+    try {
+        $pacOutput = @(& pac --version 2>$null)
+        $pacVersionLine = $pacOutput | Where-Object { $_ -match '^Version:\s*' } | Select-Object -First 1
+        if ($pacVersionLine -match '^Version:\s*(?<Value>.+)$') {
+            $pacVersion = $Matches['Value'].Trim()
+        }
+        elseif ($pacOutput.Count -gt 0) {
+            $pacVersion = $pacOutput[0].Trim()
+        }
+
+        if ([string]::IsNullOrWhiteSpace($pacVersion)) {
+            $pacVersion = $null
+        }
+    }
+    catch {
+        $pacVersion = $null
+    }
+
+    $gitVersion = $null
+    try {
+        $gitVersion = (& git --version 2>$null | Select-Object -First 1)
+        if ($gitVersion -match '^git version\s+(?<Value>.+)$') {
+            $gitVersion = $Matches['Value'].Trim()
+        }
+        if ([string]::IsNullOrWhiteSpace($gitVersion)) {
+            $gitVersion = $null
+        }
+    }
+    catch {
+        $gitVersion = $null
+    }
+
+    $vsCodeVersion = $null
+    try {
+        $vsCodeVersion = (& code --version 2>$null | Select-Object -First 1)
+        if ([string]::IsNullOrWhiteSpace($vsCodeVersion)) {
+            $vsCodeVersion = $null
+        }
+    }
+    catch {
+        $vsCodeVersion = $null
+    }
+
+    $powerShellVersion = $PSVersionTable.PSVersion.ToString()
+
+    Write-Host 'Copilot Studio Project Status' -ForegroundColor Green
+    Write-Host '-----------------------------' -ForegroundColor Green
+    Write-Host ("Agent Name      : {0}" -f $agentName)
+    Write-Host ("Agent Root      : {0}" -f $agentRoot)
+    Write-Host ("Agent File      : {0}" -f $agentFile.FullName)
+
+    Write-Section 'Counts'
+    Write-Host ("Topics          : {0}" -f $topicCount)
+    Write-Host ("Actions         : {0}" -f $actionCount)
+    Write-Host ("Variables       : {0}" -f $variableCount)
+    Write-Host ("Workflows       : {0}" -f $workflowCount)
+
+    Write-Section 'Git'
+    if ($repoRoot) {
+        Write-Host ("Repository Root : {0}" -f $repoRoot)
+        Write-Host ("Modified Files  : {0}" -f $gitStatus.Count)
+        if ($dirtyWorkflowFiles.Count -gt 0) {
+            Write-Host 'Dirty workflow files detected:' -ForegroundColor Yellow
+            $dirtyWorkflowFiles | ForEach-Object { Write-Host ("  - {0}" -f $_) -ForegroundColor Yellow }
+        }
+        else {
+            Write-Host 'Dirty workflow files: none' -ForegroundColor Green
+        }
+    }
+    else {
+        Write-Host 'Git repository  : not detected' -ForegroundColor Yellow
+    }
+
+    Write-Section 'Tooling'
+    if ($pacVersion) {
+        Write-Host ("pac CLI         : {0}" -f $pacVersion) -ForegroundColor Green
+    }
+    else {
+        Write-Host 'pac CLI         : not installed or not on PATH' -ForegroundColor Yellow
+    }
+
+    Write-Section 'Dependencies'
+    if ($gitVersion) {
+        Write-Host ("Git             : {0}" -f $gitVersion) -ForegroundColor Green
+    }
+    else {
+        Write-Host 'Git             : not installed or not on PATH' -ForegroundColor Yellow
+    }
+
+    if ($vsCodeVersion) {
+        Write-Host ("VS Code         : {0}" -f $vsCodeVersion) -ForegroundColor Green
+    }
+    else {
+        Write-Host 'VS Code         : not on PATH' -ForegroundColor Yellow
+    }
+
+    Write-Host ("PowerShell      : {0}" -f $powerShellVersion) -ForegroundColor Green
+
+    if ($pacVersion) {
+        Write-Host ("pac CLI         : {0}" -f $pacVersion) -ForegroundColor Green
+    }
+    else {
+        Write-Host 'pac CLI         : not installed' -ForegroundColor Yellow
+    }
+}
+catch {
+    Write-Host ("Error: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
Distributable Copilot CLI skill for building Copilot Studio agents:
- plugin.json manifest for 'copilot plugin install' from GitHub
- SKILL.md with dev workflow, prerequisites, gotchas, best practices
- 4 PowerShell scripts: status, revert, preflight, add-component
- Reference docs: gotchas deep-dive, workflow guide
- CHANGELOG.md with semver versioning
- Compatible with Copilot CLI, Claude Code, VS Code, Cloud Agent

Install: copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow
