### PR TITLE
Add skill showcase + revamp READMEs 

### DIFF
--- a/copilot-agent-samples/README.md
+++ b/copilot-agent-samples/README.md
@@ -1,40 +1,66 @@
-# 🚀 FastTrack for Copilot Agents 🚀
+# 🚀 FastTrack for Copilot Agents
 
-Welcome to the official FastTrack repository for agent templates! 👋 This is your one-stop-shop for getting a head start on building powerful and intelligent agents for both **Microsoft Copilot Studio** and **Agent Builder**.
+Welcome to the official FastTrack repository for agent samples, skills, and templates. Whether you're building on **Copilot Studio**, **Agent Builder**, or **GitHub Copilot CLI** — start here.
 
-Whether you're a seasoned pro or just getting started, these templates are designed to accelerate your development process and showcase what's possible.
+---
 
-## 📂 Repository Structure
+## 📂 What's Inside
 
-This repository is organized into two main directories, one for each platform:
+### 🤖 Copilot Studio Agents
 
-* `copilot-studio-agents/`
-    * Contains agent templates, examples, and solutions specifically designed for **Microsoft Copilot Studio**. These are great for building sophisticated, enterprise-grade agents. Our sample **custom agents** are prefixed with `ca-` . 
+Enterprise-grade agents built on Microsoft Copilot Studio with Power Platform.
 
-* `agent-builder-agents/`
-    * Contains agent templates tailored for the **Agent Builder** in Copilot. These are perfect for creating more focused, task-oriented agents quickly. Note these can also be easily repurposed to be used with SharePoint Agents. Our sample **declarative agents** are prefixed with `da-` . 
+| Agent | Description |
+|---|---|
+| [**PowerClaw**](copilot-studio-agents/ca-PowerClawAgent/) | 24/7 AI Chief of Staff — autonomous heartbeat, persistent memory, SharePoint brain, and a [Skills Library](copilot-studio-agents/ca-PowerClawAgent/skills/) with 8 extensible capabilities |
+
+→ Browse [`copilot-studio-agents/`](copilot-studio-agents/) for all samples (prefixed `ca-`)
+
+### 🏗️ Agent Builder Agents
+
+Declarative agents for M365 Copilot and Teams — lightweight, task-focused, fast to deploy.
+
+→ Browse [`agent-builder-agents/`](agent-builder-agents/) for all samples (prefixed `da-`)
+
+### 🖥️ GitHub Copilot Agents
+
+Custom agents for the GitHub Copilot CLI — multi-model, terminal-native, plugin-installable.
+
+| Agent | Description |
+|---|---|
+| [**AI Council**](github-copilot-agents/Council/) | Multi-model deliberation — Claude, GPT & Gemini debate any question and produce interactive decision dashboards |
+
+→ Browse [`github-copilot-agents/`](github-copilot-agents/) for all samples
+
+### 🔧 GitHub Copilot Skills
+
+Reusable skill plugins that teach Copilot CLI (and Claude Code) how to perform specialized tasks.
+
+| Skill | Description | Install |
+|---|---|---|
+| [**copilot-studio-workflow**](github-copilot-skills/copilot-studio-workflow/) | Dev workflow for building Copilot Studio agents — pull/push loop, packaging, gotchas, best practices | `copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow` |
+
+→ Browse [`github-copilot-skills/`](github-copilot-skills/) for all skills
+
+---
 
 ## ✨ Getting Started
 
-Using these templates is simple!
+1. **Clone** this repo
+2. **Navigate** to the agent or skill that interests you
+3. **Follow** the README inside each sample for setup instructions
+4. **Customize** — adapt it to your needs, make it your own
 
-1.  **Clone or Download:** Clone this repository or download the ZIP file to your local machine.
-2.  **Explore:** Navigate into either the `copilot-studio-agents` or `agent-builder-agents` directory.
-3.  **Import:** Follow the instructions within each template's own README to import it into your Copilot Studio or Agent Builder environment.
-4.  **Customize:** Adapt the template to your specific needs. Change the logic, add new capabilities, and make it your own!
+---
 
 ## 🤝 Contributing
 
-Have a great agent template you'd like to share with the community? We'd love your contributions!
+Have a great agent, skill, or template to share? We'd love your contributions!
 
-1.  **Fork** this repository.
-2.  **Create a new branch** for your feature (`git checkout -b feature/my-awesome-agent`).
-3.  **Add your template** to the appropriate directory, including a clear README.md file explaining what it does and how to use it.
-4.  **Commit your changes** (`git commit -m 'Add some awesome agent'`).
-5.  **Push to the branch** (`git push origin feature/my-awesome-agent`).
-6.  **Open a Pull Request** and we'll review it.
-
-Let's build an amazing collection of agent templates together! 🎉
+1. **Fork** this repository
+2. **Create a branch** (`git checkout -b feature/my-awesome-agent`)
+3. **Add your sample** to the appropriate directory with a clear README
+4. **Open a Pull Request** and we'll review it
 
 ---
 

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/README.md
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/README.md
@@ -1,137 +1,174 @@
 # copilot-studio-workflow
+**Build Copilot Studio agents like software: local YAML, source control, repeatable packaging, and an AI assistant that already knows the platform's sharp edges.**
 
-A development workflow skill for building, syncing, packaging, and shipping Copilot Studio agents.
-
-## What this skill does
-- Teaches the proven **pull → revert → edit → push → publish → test → commit** loop
-- Captures platform gotchas around sync, solution packaging, variables, and flows
-- Ships helper PowerShell scripts for project status, workflow reverts, preflight checks, and solution component adds
-- Includes best practices for agent architecture, YAML hygiene, testing, memory, and security
-- Provides deeper reference docs for day-to-day development and production packaging
-
-## Install
-
-### From GitHub (recommended)
-
-Install directly from the FastTrack repository:
+![Version](https://img.shields.io/badge/version-1.0.0-2563eb?style=for-the-badge)
+![Platform](https://img.shields.io/badge/platform-Copilot%20CLI%20%7C%20VS%20Code%20%7C%20Claude%20Code%20%7C%20Cloud%20Agent-111827?style=for-the-badge)
+![License](https://img.shields.io/badge/license-MIT-16a34a?style=for-the-badge)
+[![Install](https://img.shields.io/badge/install-copilot%20plugin%20install-7c3aed?style=for-the-badge&logo=github)](#quick-install)
 
 ```sh
 copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow
 ```
 
-Update to the latest version:
+> 📖 **[View the interactive showcase →](skills/copilot-studio-workflow/docs/showcase.html)** — see the full workflow, example conversations, and platform gotchas in a visual guide.
 
-```sh
-copilot plugin update copilot-studio-workflow
-```
+## Why This Exists
+Copilot Studio is powerful, but the default workflow is still portal-heavy: click through the UI, hope you remember what changed, and figure out packaging only when it is time to ship. That is workable for demos. It is not a good engineering workflow.
 
-### From the CLI (interactive)
+This skill gives builders a better model. Your agent definition lives as YAML in git. You pull from the cloud, revert environment-specific artifacts, edit locally, push intentionally, publish, test in the real channel, and package for deployment with a repeatable process. Instead of learning the platform by trial and error, you can ask for the next step in plain English and get workflow-aware guidance.
 
+It also bakes in the painful lessons most teams discover the hard way: why pull dirties workflow files, why push does not update solution membership, why variable hygiene matters for imports, and how to move from dev environment to clean solution zip without surprises. The result is a Copilot Studio workflow that feels like engineering, not archaeology.
+
+## What You Can Do
+### 1) First-time setup
 ```text
-/plugin add
+You: I need to start building a Copilot Studio agent. What's the workflow?
+
+Copilot: I'll walk you through the local dev loop, run cps-status.ps1, and
+make sure VS Code plus the Copilot Studio extension are ready before you pull
+or push anything.
 ```
 
-Then search for `copilot-studio-workflow`.
+### 2) Pull changes safely
+```text
+You: I just pulled my agent from the cloud and git shows a bunch of changed
+workflow files. What happened?
 
-### Manual — personal skill (all repos)
+Copilot: That's the environment URL translation problem. A pull can bring
+live URLs and settings into repo files. Run cps-revert.ps1 now, then review a
+clean diff that only shows intentional source changes.
+```
+
+### 3) Add a new topic to the solution
+```text
+You: I pushed a new topic via VS Code but it's not showing up in my solution
+export. What's wrong?
+
+Copilot: Push created the Dataverse component, but it did not add that
+component to the Power Platform solution. Run cps-add-component.ps1 with the
+solution name and schema pattern, then re-export.
+```
+
+### 4) Validate before push
+```text
+You: I'm about to push my changes. Anything I should check first?
+
+Copilot: Run cps-preflight.ps1. It will catch dirty workflow files, missing
+variable definitions, and basic repo hygiene issues before the push becomes a
+cloud problem.
+```
+
+## Quick Install
+### GitHub Copilot CLI
+Run this in your terminal:
+```sh
+copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow
+```
+Update later with `copilot plugin update copilot-studio-workflow`.
+
+After install, just ask naturally:
+- `Help me safely push my Copilot Studio YAML changes.`
+- `Why did my pull dirty workflow JSON files?`
+- `How do I package this agent for production?`
+- `Run a preflight check before I push.`
+
+> Tip: If needed, force activation by including `/copilot-studio-workflow` in your prompt.
+
+## Other Install Methods
+<details>
+<summary><strong>Manual install — personal skill (all repos)</strong></summary>
 
 Copy the inner skill folder to your personal skills directory.
 
-**Windows:**
-
+**Windows**
 ```powershell
 $src = "path\\to\\copilot-studio-workflow\\skills\\copilot-studio-workflow"
 Copy-Item -Recurse $src "$env:USERPROFILE\\.copilot\\skills\\copilot-studio-workflow"
 ```
 
-**macOS / Linux:**
-
+**macOS / Linux**
 ```bash
 cp -r path/to/copilot-studio-workflow/skills/copilot-studio-workflow ~/.copilot/skills/
 ```
+</details>
 
-### Manual — project skill (single repo)
+<details>
+<summary><strong>Manual install — project skill (single repo)</strong></summary>
 
-Copy the inner skill folder into your repository.
-
-**Windows:**
-
+**Windows**
 ```powershell
 Copy-Item -Recurse .\skills\copilot-studio-workflow .\.github\skills\copilot-studio-workflow
 ```
 
-**macOS / Linux:**
-
+**macOS / Linux**
 ```bash
 cp -r skills/copilot-studio-workflow .github/skills/copilot-studio-workflow
 ```
+</details>
 
-### Claude Code
-
-Copy the inner skill folder to your Claude skills directory:
+<details>
+<summary><strong>Claude Code</strong></summary>
 
 ```bash
 cp -r skills/copilot-studio-workflow ~/.claude/skills/copilot-studio-workflow
 ```
+</details>
 
-## Prerequisites
-- Git
-- PowerShell (7+ recommended, 5.1 works on Windows)
-- `pac` CLI is optional but recommended for solution packaging
+## What's Inside
+| File | Why it matters |
+|---|---|
+| `skills/copilot-studio-workflow/SKILL.md` | Core workflow logic, triggers, and operational guidance |
+| `skills/copilot-studio-workflow/scripts/cps-status.ps1` | Checks project health, tool availability, and repo state |
+| `skills/copilot-studio-workflow/scripts/cps-revert.ps1` | Cleans up pull-induced workflow and settings churn |
+| `skills/copilot-studio-workflow/scripts/cps-preflight.ps1` | Runs pre-push hygiene checks before you sync |
+| `skills/copilot-studio-workflow/scripts/cps-add-component.ps1` | Adds pushed components to the Power Platform solution |
+| `skills/copilot-studio-workflow/reference/gotchas.md` | Documents platform traps and workarounds |
+| `skills/copilot-studio-workflow/reference/workflow-guide.md` | Expands the day-to-day development and packaging loop |
+| `skills/copilot-studio-workflow/docs/showcase.html` | Interactive visual guide to the skill and workflow |
+| `plugin.json` | Plugin manifest for `copilot plugin install` |
+| `CHANGELOG.md` | Release history |
 
 ## Compatibility
+![Copilot CLI](https://img.shields.io/badge/GitHub_Copilot_CLI-supported-000000?style=flat-square&logo=github)
+![VS Code](https://img.shields.io/badge/VS_Code_Copilot-supported-007acc?style=flat-square&logo=visualstudiocode)
+![Claude Code](https://img.shields.io/badge/Claude_Code-supported-d97706?style=flat-square)
+![Cloud Agent](https://img.shields.io/badge/Copilot_Cloud_Agent-supported-2563eb?style=flat-square)
 
-| Tool | Install method |
-|---|---|
-| **GitHub Copilot CLI** | `copilot plugin install` or personal skill at `~/.copilot/skills/` |
-| **Claude Code** | Personal skill at `~/.claude/skills/` |
-| **VS Code Copilot** | Project skill at `.github/skills/` |
-| **Copilot Cloud Agent** | Project skill at `.github/skills/` |
+| Tool | Status | Install path |
+|---|---|---|
+| GitHub Copilot CLI | Recommended | Plugin install or `~/.copilot/skills/` |
+| VS Code Copilot | Supported | `.github/skills/` |
+| Claude Code | Supported | `~/.claude/skills/` |
+| Copilot Cloud Agent | Supported | `.github/skills/` |
 
-The `SKILL.md` format is an [open standard](https://github.com/agentskills/agentskills) supported across multiple AI coding tools.
+The `SKILL.md` format follows the [Agent Skills](https://github.com/agentskills/agentskills) open standard, so the same workflow knowledge travels across tools.
 
-## What's included
+## Prerequisites
+Keep this short list in place and the workflow becomes smooth:
+- **Git** for version control
+- **VS Code** plus the **Copilot Studio VS Code extension** for pull/push
+- **PowerShell** (7+ recommended; Windows PowerShell 5.1 works on Windows)
+- **Power Platform CLI (`pac`)** recommended for solution packaging and exports
+- Access to a **Copilot Studio-enabled Power Platform environment**
 
-| File | Purpose |
-|---|---|
-| `plugin.json` | Plugin manifest for `copilot plugin install` |
-| `CHANGELOG.md` | Version history |
-| `skills/copilot-studio-workflow/SKILL.md` | Core skill instructions |
-| `skills/copilot-studio-workflow/scripts/cps-status.ps1` | Project health check |
-| `skills/copilot-studio-workflow/scripts/cps-revert.ps1` | Workflow file revert |
-| `skills/copilot-studio-workflow/scripts/cps-preflight.ps1` | Pre-push hygiene checks |
-| `skills/copilot-studio-workflow/scripts/cps-add-component.ps1` | Add component to solution |
-| `skills/copilot-studio-workflow/reference/gotchas.md` | Platform gotchas deep-dive |
-| `skills/copilot-studio-workflow/reference/workflow-guide.md` | Workflow documentation |
-
-## How to use
-
-After installing, the skill activates automatically when your prompts mention Copilot Studio, `.mcs.yml`, solution packaging, `pac` CLI, or related topics.
-
-Examples:
-- "Help me push these Copilot Studio YAML changes safely."
-- "How do I package this Copilot Studio agent for production?"
-- "Why did my pull dirty workflow JSON files?"
-- "Run a preflight check before I push."
-
-Force activation: include `/copilot-studio-workflow` in your prompt.
+Run `skills\copilot-studio-workflow\scripts\cps-status.ps1` to validate the local setup.
 
 ## Versioning
-
-This plugin uses [Semantic Versioning](https://semver.org/). Check `CHANGELOG.md` for the full version history.
-
-To update:
-
-```sh
-copilot plugin update copilot-studio-workflow
-```
+This plugin uses [Semantic Versioning](https://semver.org/). Current version: **1.0.0**.
+- Release notes: `CHANGELOG.md`
+- Update: `copilot plugin update copilot-studio-workflow`
 
 ## Contributing
-- Keep `SKILL.md` concise — it is loaded directly into context
-- Put detailed explanations in `reference/`
+Keep the skill lean and operational:
+- Put core instructions in `SKILL.md`
+- Put deeper explanations in `reference/`
 - Keep scripts safe to run repeatedly
-- Bump the version in both `plugin.json` and `CHANGELOG.md` on every release
-- Test scripts: `powershell -NoProfile -File skills\\copilot-studio-workflow\\scripts\\<name>.ps1 -?`
+- Bump `plugin.json` and `CHANGELOG.md` together on release
+
+Quick script check:
+```powershell
+powershell -NoProfile -File skills\copilot-studio-workflow\scripts\<name>.ps1 -?
+```
 
 ## License
 MIT

--- a/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/docs/showcase.html
+++ b/copilot-agent-samples/github-copilot-skills/copilot-studio-workflow/skills/copilot-studio-workflow/docs/showcase.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>copilot-studio-workflow Showcase</title>
+  <style>
+    :root {
+      --sidebar-bg:#1e1b4b; --sidebar-border:rgba(255,255,255,.12); --page-bg:#f6f3ff; --panel-bg:#fff; --panel-muted:#f8f7ff;
+      --text:#1f2937; --muted:#5b6475; --heading:#111827; --accent:#7c3aed; --accent-strong:#6d28d9; --accent-soft:#ede9fe;
+      --accent-line:#d8c8ff; --line:#e5e7eb; --shadow:0 28px 70px rgba(30,27,75,.11); --warning-bg:#fffbeb; --warning-border:#f59e0b;
+      --warning-text:#92400e; --success-bg:#f5f3ff; --success-border:#c4b5fd; --radius-xl:26px; --radius-lg:20px; --radius-md:16px;
+    }
+    * { box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body {
+      margin:0; color:var(--text); font-family:"Segoe UI Variable","Segoe UI","Trebuchet MS",sans-serif; line-height:1.6;
+      background:radial-gradient(circle at top right, rgba(124,58,237,.12), transparent 24%), linear-gradient(180deg, #fcfbff 0%, var(--page-bg) 100%);
+    }
+    a { color:var(--accent-strong); text-decoration:none; }
+    a:hover { text-decoration:underline; }
+    code, pre, kbd { font-family:"Cascadia Code","Consolas","Courier New",monospace; }
+    .layout { display:grid; grid-template-columns:300px minmax(0,1fr); min-height:100vh; }
+    .sidebar {
+      position:sticky; top:0; height:100vh; padding:28px 22px; color:#f5f3ff;
+      background:radial-gradient(circle at top, rgba(255,255,255,.08), transparent 26%), linear-gradient(180deg, #23195f 0%, var(--sidebar-bg) 68%);
+      border-right:1px solid var(--sidebar-border);
+    }
+    .brand { display:grid; gap:10px; padding-bottom:22px; margin-bottom:20px; border-bottom:1px solid var(--sidebar-border); }
+    .brand-mark {
+      width:46px; height:46px; display:inline-grid; place-items:center; border-radius:14px; background:rgba(255,255,255,.12); color:#fff; font-size:1.4rem;
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.08);
+    }
+    .brand h1 { margin:0; color:#fff; font-size:1.3rem; line-height:1.15; letter-spacing:-.03em; }
+    .brand p, .sidebar-note, .sidebar-meta { margin:0; color:rgba(245,243,255,.76); }
+    .sidebar-stack { display:grid; gap:16px; }
+    .nav-label { margin:0 0 12px; font-size:.72rem; text-transform:uppercase; letter-spacing:.14em; color:rgba(245,243,255,.5); }
+    .nav-list { list-style:none; padding:0; margin:0; display:grid; gap:6px; }
+    .nav-list a {
+      display:block; padding:10px 12px; border-radius:12px; color:rgba(245,243,255,.82);
+      transition:transform 180ms ease, background-color 180ms ease, color 180ms ease;
+    }
+    .nav-list a:hover, .nav-list a:focus-visible, .nav-list a.active {
+      text-decoration:none; color:#fff; background:rgba(124,58,237,.35); transform:translateX(2px); outline:none;
+    }
+    .sidebar-note, .sidebar-meta {
+      padding:14px; border-radius:16px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.08); font-size:.92rem;
+    }
+    .sidebar-note strong, .sidebar-meta strong { color:#fff; }
+    .main { padding:34px; }
+    .content { max-width:1160px; margin:0 auto; }
+    .hero, .section-card {
+      background:var(--panel-bg); border:1px solid rgba(17,24,39,.06); border-radius:var(--radius-xl); box-shadow:var(--shadow);
+    }
+    .hero { position:relative; overflow:hidden; padding:36px; margin-bottom:24px; }
+    .hero::after {
+      content:""; position:absolute; inset:auto -90px -110px auto; width:280px; height:280px; border-radius:50%;
+      background:radial-gradient(circle, rgba(124,58,237,.18), rgba(124,58,237,0) 72%); pointer-events:none;
+    }
+    .eyebrow, .section-kicker, .badge, .workflow-label {
+      display:inline-flex; align-items:center; gap:8px; border-radius:999px; font-weight:700; letter-spacing:.03em;
+    }
+    .eyebrow { padding:8px 13px; background:var(--accent-soft); color:var(--accent-strong); font-size:.82rem; }
+    .hero h2, .section-header h2 { margin:0; color:var(--heading); font-family:"Cambria","Georgia",serif; letter-spacing:-.04em; }
+    .hero h2 { margin-top:18px; font-size:clamp(2.2rem, 5vw, 4rem); line-height:.98; max-width:10.5ch; }
+    .hero .tagline { margin:14px 0 0; color:var(--heading); font-size:clamp(1.15rem, 2vw, 1.45rem); font-weight:700; }
+    .hero .subtagline, .section-header p, .lede, .feature-copy, .workflow-card p, .problem-card p, .step-card p, .install-note p, .footer { color:var(--muted); }
+    .hero .subtagline { margin:8px 0 0; font-size:1.06rem; max-width:60ch; }
+    .hero-grid { display:grid; grid-template-columns:minmax(0,1.35fr) minmax(320px,.95fr); gap:20px; align-items:stretch; margin-top:28px; }
+    .hero-panel, .install-panel, .stat-card, .problem-card, .feature-card, .step-card, .workflow-card, .gotcha-card, .install-note {
+      border-radius:var(--radius-lg); border:1px solid var(--line); background:linear-gradient(180deg, #fff 0%, #fcfbff 100%);
+    }
+    .hero-panel { padding:20px; background:linear-gradient(180deg, #fbfaff 0%, #f7f4ff 100%); border-color:var(--accent-line); }
+    .hero-panel h3, .install-panel h3, .problem-card h3, .feature-card h3, .step-card h3, .workflow-card h3, .gotcha-card h3, .chat-example h3, .install-note h3 {
+      margin:0 0 10px; color:var(--heading); font-size:1rem; line-height:1.3;
+    }
+    .hero-panel ul, .feature-card ul, .install-note ul { margin:12px 0 0; padding-left:18px; }
+    .hero-panel li + li, .feature-card li + li, .install-note li + li { margin-top:8px; }
+    .install-panel {
+      padding:22px; position:relative; z-index:1; background:linear-gradient(180deg, rgba(124,58,237,.08), rgba(124,58,237,.03)), #fff;
+      border-color:rgba(124,58,237,.24);
+    }
+    .install-panel h3, .section-kicker { font-size:.76rem; text-transform:uppercase; }
+    .install-panel h3 { letter-spacing:.14em; color:var(--accent-strong); }
+    .command-block, .flow-band, .terminal, .path-strip {
+      background:#120f2f; color:#f5f3ff; border-radius:18px; border:1px solid rgba(124,58,237,.28); overflow:hidden;
+    }
+    .command-label, .terminal-bar {
+      display:flex; align-items:center; gap:8px; padding:10px 14px; font-size:.83rem; color:rgba(245,243,255,.72);
+      border-bottom:1px solid rgba(255,255,255,.08); background:rgba(255,255,255,.04);
+    }
+    .dot { width:10px; height:10px; border-radius:50%; background:rgba(255,255,255,.28); }
+    .command-block pre, .flow-band pre { margin:0; padding:16px 18px; background:transparent; border:none; color:#ede9fe; overflow-x:auto; }
+    .command-footnote { margin:12px 0 0; color:var(--muted); font-size:.94rem; }
+    .stats-grid, .problem-grid, .feature-grid, .steps-grid, .chat-grid, .workflow-grid, .gotcha-grid, .install-grid { display:grid; gap:16px; }
+    .stats-grid { margin-top:18px; grid-template-columns:repeat(3, minmax(0,1fr)); }
+    .stat-card { padding:16px; background:#fff; }
+    .stat-card strong { display:block; font-size:1.7rem; color:var(--heading); line-height:1; margin-bottom:6px; }
+    .stat-card span { color:var(--muted); font-size:.95rem; }
+    .section-card { padding:30px; margin-bottom:22px; scroll-margin-top:18px; }
+    .section-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:14px; align-items:end; margin-bottom:18px; }
+    .section-header h2 { font-size:clamp(1.55rem, 2vw, 2.1rem); line-height:1.06; }
+    .section-header p { margin:0; max-width:46ch; }
+    .section-kicker { padding:6px 12px; background:var(--accent-soft); color:var(--accent-strong); }
+    .lede { margin:0 0 18px; font-size:1.02rem; max-width:72ch; }
+    .callout { margin-top:18px; padding:16px 18px; border-radius:16px; border:1px solid var(--success-border); background:var(--success-bg); }
+    .callout strong { color:var(--heading); }
+    .problem-grid { grid-template-columns:repeat(2, minmax(0,1fr)); margin-top:20px; }
+    .problem-card, .step-card, .feature-card, .workflow-card, .gotcha-card, .install-note { padding:18px 20px; }
+    .problem-card p, .step-card p, .gotcha-card p { margin:0; font-size:.95rem; }
+    .flow-band { margin:20px 0 18px; }
+    .steps-grid { grid-template-columns:repeat(7, minmax(0,1fr)); }
+    .badge { min-width:34px; justify-content:center; padding:6px 10px; margin-bottom:12px; background:var(--accent-soft); color:var(--accent-strong); font-size:.82rem; }
+    .feature-grid { grid-template-columns:repeat(2, minmax(0,1fr)); margin-top:20px; }
+    .feature-card { background:linear-gradient(180deg, #fff 0%, #faf9ff 100%); }
+    .feature-head { display:flex; gap:14px; align-items:flex-start; }
+    .feature-icon {
+      width:42px; height:42px; display:grid; place-items:center; flex:0 0 42px; border-radius:14px; background:var(--accent-soft); color:var(--accent-strong); font-size:1.1rem;
+    }
+    .feature-copy { margin:0; }
+    .chat-grid { grid-template-columns:repeat(2, minmax(0,1fr)); margin-top:18px; }
+    .chat-example { border:1px solid var(--line); border-radius:22px; background:linear-gradient(180deg, #fff 0%, #fbfaff 100%); overflow:hidden; }
+    .chat-example h3 { padding:18px 20px 0; margin-bottom:6px; }
+    .chat-example p { margin:0; padding:0 20px 16px; color:var(--muted); font-size:.95rem; }
+    .terminal-thread { padding:18px; display:grid; gap:12px; background:linear-gradient(180deg, #16122f 0%, #1a1739 100%); }
+    .message {
+      max-width:92%; padding:12px 14px; border-radius:16px; font-size:.95rem; line-height:1.55; border:1px solid transparent;
+    }
+    .message strong { display:block; margin-bottom:6px; font-size:.78rem; letter-spacing:.08em; text-transform:uppercase; }
+    .message.user { margin-left:auto; background:rgba(124,58,237,.24); border-color:rgba(196,181,253,.35); color:#f5f3ff; }
+    .message.assistant { background:rgba(255,255,255,.92); border-color:rgba(255,255,255,.16); color:#1f2937; }
+    .message.assistant code, .install-note code { background:#efe9ff; }
+    .workflow-grid { grid-template-columns:repeat(2, minmax(0,1fr)); margin-top:18px; }
+    .workflow-label { margin-bottom:12px; padding:6px 10px; background:var(--accent-soft); color:var(--accent-strong); font-size:.82rem; }
+    .path-strip { margin-top:14px; padding:12px 14px; font-size:.88rem; line-height:1.55; }
+    .gotcha-grid { grid-template-columns:repeat(3, minmax(0,1fr)); margin-top:18px; }
+    .gotcha-card {
+      background:linear-gradient(180deg, var(--warning-bg) 0%, #fffef6 100%); border-color:rgba(245,158,11,.42); box-shadow:inset 0 0 0 1px rgba(255,255,255,.4);
+    }
+    .gotcha-card h3 { color:#7c2d12; }
+    .gotcha-card p { color:var(--warning-text); }
+    .install-grid { grid-template-columns:minmax(0,1.1fr) minmax(280px,.9fr); margin-top:18px; align-items:start; }
+    .compatibility { display:flex; flex-wrap:wrap; gap:10px; margin:14px 0 0; }
+    .compatibility span {
+      padding:7px 12px; border-radius:999px; background:#f4f1ff; border:1px solid var(--accent-line); color:var(--accent-strong); font-size:.86rem; font-weight:600;
+    }
+    table { width:100%; border-collapse:collapse; margin-top:18px; border:1px solid var(--line); border-radius:18px; overflow:hidden; }
+    th, td { padding:14px 16px; border-bottom:1px solid var(--line); vertical-align:top; text-align:left; }
+    th { background:#f2eeff; color:#4c1d95; font-size:.9rem; }
+    tbody tr:nth-child(even) { background:var(--panel-muted); }
+    tbody tr:last-child td { border-bottom:none; }
+    .footer { padding:10px 4px 24px; text-align:center; font-size:.92rem; }
+    .footer strong { color:var(--heading); }
+    @media (max-width:1180px) {
+      .layout { grid-template-columns:1fr; }
+      .sidebar { position:relative; height:auto; }
+      .hero-grid, .install-grid, .problem-grid, .feature-grid, .chat-grid, .workflow-grid, .gotcha-grid { grid-template-columns:1fr; }
+      .steps-grid { grid-template-columns:repeat(2, minmax(0,1fr)); }
+    }
+    @media (max-width:760px) {
+      .main { padding:16px; }
+      .sidebar { padding:22px 18px; }
+      .hero, .section-card { padding:22px; border-radius:22px; }
+      .hero-grid, .stats-grid, .steps-grid { grid-template-columns:1fr; }
+      .section-header { display:block; }
+      th, td { padding:12px; }
+    }
+    @media print {
+      body { background:#fff; }
+      .layout { display:block; }
+      .sidebar { display:none; }
+      .main { padding:0; }
+      .hero, .section-card, .chat-example, .workflow-card, .gotcha-card { box-shadow:none; border:1px solid #d1d5db; break-inside:avoid; }
+      a { color:inherit; text-decoration:none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Showcase navigation">
+      <div class="brand">
+        <div class="brand-mark" aria-hidden="true">✦</div>
+        <div>
+          <h1>copilot-studio-workflow</h1>
+          <p>FastTrack’s workflow skill for building Copilot Studio agents with engineering discipline.</p>
+        </div>
+      </div>
+      <div class="sidebar-stack">
+        <div>
+          <p class="nav-label">Navigate</p>
+          <ul class="nav-list">
+            <li><a href="#hero">Overview</a></li>
+            <li><a href="#problem">The Problem</a></li>
+            <li><a href="#solution">The Solution</a></li>
+            <li><a href="#teaches">What It Teaches</a></li>
+            <li><a href="#conversations">Example Conversations</a></li>
+            <li><a href="#variations">Workflow Variations</a></li>
+            <li><a href="#gotchas">Platform Gotchas</a></li>
+            <li><a href="#install">Install</a></li>
+          </ul>
+        </div>
+        <div class="sidebar-note"><strong>Core mental model:</strong> YAML in git is the source of truth, the cloud is the integration target, and the solution zip is the production handoff.</div>
+        <div class="sidebar-meta"><strong>Community spark:</strong> inspired by Alvin Abia-Williams’ AI-assisted Power Platform workflow and refined through the PowerClaw team’s real-world Copilot Studio delivery loop.</div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <div class="content">
+        <header class="hero" id="hero">
+          <span class="eyebrow">FastTrack skill showcase</span>
+          <h2>copilot-studio-workflow</h2>
+          <p class="tagline">Build Copilot Studio agents like software.</p>
+          <p class="subtagline">Source control. Repeatable workflows. AI that knows the platform’s sharp edges.</p>
+          <div class="hero-grid">
+            <section class="hero-panel" aria-labelledby="value-heading">
+              <h3 id="value-heading">Why builders install this</h3>
+              <p class="feature-copy">This skill teaches your AI assistant the full professional loop: how to pull safely, scrub environment noise, edit YAML locally, package with PAC CLI, publish deliberately, and avoid the undocumented mistakes that normally cost hours.</p>
+              <ul>
+                <li>Works with GitHub Copilot CLI, Claude Code, VS Code, and cloud agents.</li>
+                <li>Encodes the PowerClaw team’s repeatable workflow instead of generic portal advice.</li>
+                <li>Turns natural language prompts into platform-aware guidance and helper-script actions.</li>
+              </ul>
+            </section>
+            <section class="install-panel" aria-labelledby="install-command-heading">
+              <h3 id="install-command-heading">Install command</h3>
+              <div class="command-block" aria-label="Install command">
+                <div class="command-label"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>Terminal</span></div>
+                <pre><code>copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow</code></pre>
+              </div>
+              <p class="command-footnote">Install once, then ask naturally: “Help me safely push my Copilot Studio changes.”</p>
+            </section>
+          </div>
+          <section class="stats-grid" aria-label="Showcase stats">
+            <div class="stat-card"><strong>5</strong><span>5 workflows covered</span></div>
+            <div class="stat-card"><strong>11</strong><span>11 platform gotchas encoded</span></div>
+            <div class="stat-card"><strong>4</strong><span>4 helper scripts included</span></div>
+          </section>
+        </header>
+
+        <section class="section-card" id="problem">
+          <div class="section-header">
+            <div><span class="section-kicker">1 · The Problem</span><h2>Copilot Studio is powerful, but the default workflow is still portal-first.</h2></div>
+            <p>Without an engineering workflow, every change becomes harder to review, harder to package, and harder to trust.</p>
+          </div>
+          <p class="lede">Teams can absolutely ship serious agents with Copilot Studio. The friction comes from the process around it: too much portal state, too little source-control discipline, and too many rules that are only learned after something breaks.</p>
+          <div class="problem-grid">
+            <article class="problem-card"><h3>Portal-heavy editing</h3><p>Important agent changes still feel like point-and-click project work instead of clean, reviewable software development.</p></article>
+            <article class="problem-card"><h3>No default ALM mindset</h3><p>Source control, repeatable packaging, and CI/CD habits are possible, but they are not the path most builders start with.</p></article>
+            <article class="problem-card"><h3>Undocumented platform gotchas</h3><p>Pulls dirty workflow files, pushes miss solution membership, imports disable flows, and helpers often learn that too late.</p></article>
+            <article class="problem-card"><h3>Environment sharing is fragile</h3><p>Moving an agent between environments can leak live URLs, break packaging, or produce artifacts that do not reflect the intended source.</p></article>
+            <article class="problem-card"><h3>AI assistants lack platform context</h3><p>Generic coding help does not know the Copilot Studio sync model, Power Platform solution rules, or the PowerClaw team’s proven sequence.</p></article>
+            <article class="problem-card"><h3>Manual recovery wastes hours</h3><p>When the loop is unclear, teams debug repo drift, packaging gaps, and import failures instead of building better agent behavior.</p></article>
+          </div>
+        </section>
+
+        <section class="section-card" id="solution">
+          <div class="section-header">
+            <div><span class="section-kicker">2 · The Solution</span><h2>Teach your AI assistant the full dev loop — not just isolated commands.</h2></div>
+            <p>The skill turns a professional Copilot Studio workflow into natural-language guidance your assistant can apply consistently.</p>
+          </div>
+          <div class="flow-band" aria-label="Workflow loop">
+            <div class="terminal-bar"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>Professional development loop</span></div>
+            <pre><code>Pull from Cloud → Revert Env Files → Edit YAML Locally → Push to Cloud → Publish → Test in Teams → Commit to Git</code></pre>
+          </div>
+          <div class="steps-grid">
+            <article class="step-card"><span class="badge">01</span><h3>Pull from Cloud</h3><p>Start from the current agent state so your local copy matches the active environment before you touch YAML.</p></article>
+            <article class="step-card"><span class="badge">02</span><h3>Revert Env Files</h3><p>Remove cloud-introduced URLs and settings churn so git only shows intentional source changes.</p></article>
+            <article class="step-card"><span class="badge">03</span><h3>Edit YAML Locally</h3><p>Make agent changes where they belong: versioned <code>.mcs.yml</code> files, reviewed like software.</p></article>
+            <article class="step-card"><span class="badge">04</span><h3>Push to Cloud</h3><p>Sync local source into Copilot Studio deliberately, with the skill guarding against stale or unsafe assumptions.</p></article>
+            <article class="step-card"><span class="badge">05</span><h3>Publish</h3><p>A pushed draft is not done. The loop includes publishing so the real agent is actually running the new logic.</p></article>
+            <article class="step-card"><span class="badge">06</span><h3>Test in Teams</h3><p>Validate in the real channel, where auth, triggers, and runtime behavior reflect production reality.</p></article>
+            <article class="step-card"><span class="badge">07</span><h3>Commit to Git</h3><p>Capture what worked after validation, with clean source and repeatable packaging discipline intact.</p></article>
+          </div>
+          <div class="callout"><strong>What changes with this skill:</strong> instead of memorizing every step, you can work through natural language — and your AI assistant already knows when to pull first, when to revert, when to add a component, and when packaging requires PAC CLI instead of portal clicks.</div>
+        </section>
+
+        <section class="section-card" id="teaches">
+          <div class="section-header">
+            <div><span class="section-kicker">3 · What the Skill Teaches Your AI</span><h2>A platform-aware operating manual for real Copilot Studio delivery.</h2></div>
+            <p>It is more than instructions. It is workflow logic, guardrails, and helper tooling encoded for day-to-day use.</p>
+          </div>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <div class="feature-head"><div class="feature-icon" aria-hidden="true">🔄</div><div><h3>Development Loop</h3><p class="feature-copy">The proven pull → revert → edit → push → publish loop, including when real-channel testing is part of “done.”</p></div></div>
+              <ul><li>Fresh-pull discipline before every push</li><li>Git-safe cleanup after cloud sync</li><li>Natural language help for first-time setup and daily work</li></ul>
+            </article>
+            <article class="feature-card">
+              <div class="feature-head"><div class="feature-icon" aria-hidden="true">📦</div><div><h3>Solution Packaging</h3><p class="feature-copy">How to export, unpack, scrub environment URLs, and repack a production-ready solution with PAC CLI.</p></div></div>
+              <ul><li>Clean handoff artifacts for other environments</li><li>Explicit solution membership management</li><li>Production packaging without portal guesswork</li></ul>
+            </article>
+            <article class="feature-card">
+              <div class="feature-head"><div class="feature-icon" aria-hidden="true">⚠️</div><div><h3>Platform Gotchas</h3><p class="feature-copy">Eleven hard-won lessons from PowerClaw: initialization behavior, solution quirks, sync limits, import issues, and more.</p></div></div>
+              <ul><li><code>OnConversationStart</code> is unreliable</li><li>Push does not equal solution membership</li><li>Cloud pulls bring live URLs back into source</li></ul>
+            </article>
+            <article class="feature-card">
+              <div class="feature-head"><div class="feature-icon" aria-hidden="true">✅</div><div><h3>Best Practices</h3><p class="feature-copy">Architecture guidance for YAML hygiene, testing, memory design, initialization, packaging, and governance.</p></div></div>
+              <ul><li>Reliable channel-aware initialization patterns</li><li>Real-channel testing, not just test-pane confidence</li><li>Security-minded use of connectors, tools, and memory</li></ul>
+            </article>
+            <article class="feature-card">
+              <div class="feature-head"><div class="feature-icon" aria-hidden="true">🔧</div><div><h3>Helper Scripts</h3><p class="feature-copy">Four PowerShell helpers make the workflow faster: status, revert, preflight, and component management.</p></div></div>
+              <ul><li><code>cps-status.ps1</code> for project health</li><li><code>cps-revert.ps1</code> after cloud pulls</li><li><code>cps-preflight.ps1</code> before pushes</li><li><code>cps-add-component.ps1</code> for solution membership</li></ul>
+            </article>
+            <article class="feature-card">
+              <div class="feature-head"><div class="feature-icon" aria-hidden="true">🧠</div><div><h3>AI-Assisted ALM</h3><p class="feature-copy">Inspired by community workflows and refined through production delivery: version-controlled, reviewable, deployable, and explainable.</p></div></div>
+              <ul><li>Better prompts because the assistant knows the domain</li><li>Less time rediscovering platform rules</li><li>More time designing agent behavior that matters</li></ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="section-card" id="conversations">
+          <div class="section-header">
+            <div><span class="section-kicker">4 · Example Conversations</span><h2>The skill makes AI help feel operational, not generic.</h2></div>
+            <p>These are the kinds of prompts builders use when they want a capable assistant that understands the platform’s actual workflow.</p>
+          </div>
+          <div class="chat-grid">
+            <article class="chat-example">
+              <h3>Starting a new agent project</h3><p>The skill can establish the workflow before the first risky pull or push.</p>
+              <div class="terminal">
+                <div class="terminal-bar"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>Copilot session</span></div>
+                <div class="terminal-thread">
+                  <div class="message user"><strong>You</strong>I need to start building a Copilot Studio agent.</div>
+                  <div class="message assistant"><strong>Copilot</strong>I’ll walk you through the local dev loop, check prerequisites with <code>cps-status.ps1</code>, and make sure you use YAML + git as the source of truth before your first sync.</div>
+                </div>
+              </div>
+            </article>
+            <article class="chat-example">
+              <h3>Dirty workflow files after pull</h3><p>The assistant recognizes cloud URL leakage immediately.</p>
+              <div class="terminal">
+                <div class="terminal-bar"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>Copilot session</span></div>
+                <div class="terminal-thread">
+                  <div class="message user"><strong>You</strong>I just pulled and git shows dirty workflow files.</div>
+                  <div class="message assistant"><strong>Copilot</strong>That’s the environment URL translation problem. A cloud pull brought live values into repo files. Run <code>cps-revert.ps1</code> now, then review a clean diff that only shows intentional source edits.</div>
+                </div>
+              </div>
+            </article>
+            <article class="chat-example">
+              <h3>New topic missing from solution export</h3><p>The skill knows the boundary between push and packaging.</p>
+              <div class="terminal">
+                <div class="terminal-bar"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>Copilot session</span></div>
+                <div class="terminal-thread">
+                  <div class="message user"><strong>You</strong>My new topic isn’t in the solution export.</div>
+                  <div class="message assistant"><strong>Copilot</strong>Push created the Dataverse component, but it did not add that component to the solution. Run <code>cps-add-component.ps1</code>, confirm membership, then re-export the package.</div>
+                </div>
+              </div>
+            </article>
+            <article class="chat-example">
+              <h3>Preflight before push</h3><p>The assistant can catch problems before they become cloud state.</p>
+              <div class="terminal">
+                <div class="terminal-bar"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>Copilot session</span></div>
+                <div class="terminal-thread">
+                  <div class="message user"><strong>You</strong>I’m about to push — anything I should check?</div>
+                  <div class="message assistant"><strong>Copilot</strong>Run <code>cps-preflight.ps1</code>. It will catch dirty workflow files, missing variable definitions, and basic repo hygiene issues before the push becomes a platform problem.</div>
+                </div>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section-card" id="variations">
+          <div class="section-header">
+            <div><span class="section-kicker">5 · The Workflow Variations</span><h2>Five paths, one consistent mental model.</h2></div>
+            <p>Different jobs need different sequences. The skill helps your assistant pick the right one instead of mixing them together.</p>
+          </div>
+          <div class="workflow-grid">
+            <article class="workflow-card"><span class="workflow-label">A · YAML-only changes</span><h3>Most common day-to-day workflow</h3><p>Edit topics, instructions, actions, triggers, and variables locally, then sync safely.</p><div class="path-strip"><code>pull → revert → edit → push → publish → test → commit</code></div></article>
+            <article class="workflow-card"><span class="workflow-label">B · Flow changes</span><h3>Edit JSON, then deploy with translated environment values</h3><p>Use this when Power Automate flow definitions are the thing you are changing, not just YAML.</p><div class="path-strip"><code>edit JSON → deploy script injects URLs → import to env → test → commit placeholders</code></div></article>
+            <article class="workflow-card"><span class="workflow-label">C · Rebuild solution zip</span><h3>Refresh the production-ready package</h3><p>Export the exact environment state you want to ship, unpack it, scrub environment specifics, then repack cleanly.</p><div class="path-strip"><code>export → unpack → scrub URLs → repack → handoff</code></div></article>
+            <article class="workflow-card"><span class="workflow-label">D · Add new component</span><h3>Push creates the component; packaging still needs the solution step</h3><p>Find the Dataverse GUID and add the new bot component so exports contain what the demo environment already has.</p><div class="path-strip"><code>push via VS Code → find GUID → pac add-solution-component</code></div></article>
+            <article class="workflow-card"><span class="workflow-label">E · Remove component</span><h3>Deletion order matters</h3><p>Cleanly remove references, delete in Studio, delete the local file, and confirm the next export is actually clean.</p><div class="path-strip"><code>delete in Studio → delete local file → re-export</code></div></article>
+          </div>
+        </section>
+
+        <section class="section-card" id="gotchas">
+          <div class="section-header">
+            <div><span class="section-kicker">6 · Platform Gotchas</span><h2>The six issues most likely to burn time if your assistant does not know them.</h2></div>
+            <p>The skill encodes eleven total gotchas. These six are the ones builders hit first and hardest.</p>
+          </div>
+          <div class="gotcha-grid">
+            <article class="gotcha-card"><h3>OnConversationStart is unreliable</h3><p>Use <code>OnActivity(type: Message)</code> with an <code>IsBlank()</code> guard for just-in-time initialization across real channels.</p></article>
+            <article class="gotcha-card"><h3>Push ≠ solution component</h3><p>A new topic can exist in Dataverse and still be missing from your exported solution until you add it explicitly.</p></article>
+            <article class="gotcha-card"><h3>Global variables need YAML files</h3><p>UI references are not enough. If the variable definition is missing from <code>variables/</code>, packaging can break.</p></article>
+            <article class="gotcha-card"><h3>Cloud pull brings environment URLs</h3><p>Workflow JSON and settings can come back dirty with live values. Revert immediately unless you intentionally need them.</p></article>
+            <article class="gotcha-card"><h3>Solution import deactivates flows</h3><p>Successful import does not mean operational automation. Reconnect and re-enable flows as part of the checklist.</p></article>
+            <article class="gotcha-card"><h3>Extension sync is all-or-nothing</h3><p>There is no selective push or pull. Coordinate edits, pull first, and avoid overlapping cloud changes.</p></article>
+          </div>
+        </section>
+
+        <section class="section-card" id="install">
+          <div class="section-header">
+            <div><span class="section-kicker">7 · Install</span><h2>Install once. Build smarter immediately.</h2></div>
+            <p>This is for builders who want source control, repeatable workflows, and an AI assistant that understands the platform’s real rules.</p>
+          </div>
+          <div class="install-grid">
+            <section class="install-panel" aria-labelledby="primary-install-heading">
+              <h3 id="primary-install-heading">Primary install path</h3>
+              <div class="command-block">
+                <div class="command-label"><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span class="dot" aria-hidden="true"></span><span>GitHub Copilot CLI</span></div>
+                <pre><code>copilot plugin install microsoft/FastTrack:copilot-agent-samples/github-copilot-skills/copilot-studio-workflow</code></pre>
+              </div>
+              <div class="compatibility" aria-label="Compatibility badges"><span>GitHub Copilot CLI</span><span>Claude Code</span><span>VS Code</span><span>Cloud Agent</span></div>
+            </section>
+            <section class="install-note">
+              <h3>Why install now</h3>
+              <p>Because the difference between “it works in the portal” and “we can maintain this like software” is workflow clarity.</p>
+              <ul><li>Use your assistant for setup, sync, packaging, preflight, and troubleshooting.</li><li>Reduce time lost to hidden platform behavior and packaging gaps.</li><li>Adopt the same ALM posture that made PowerClaw repeatable and reviewable.</li></ul>
+            </section>
+          </div>
+          <table aria-label="Included helper scripts">
+            <thead><tr><th>Included helper</th><th>What it helps with</th></tr></thead>
+            <tbody>
+              <tr><td><code>cps-status.ps1</code></td><td>Checks project health, agent structure, git status, and local tooling readiness.</td></tr>
+              <tr><td><code>cps-revert.ps1</code></td><td>Reverts workflow and settings churn introduced by cloud pulls.</td></tr>
+              <tr><td><code>cps-preflight.ps1</code></td><td>Runs a pre-push hygiene check for dirty workflow files, missing variables, and repo state.</td></tr>
+              <tr><td><code>cps-add-component.ps1</code></td><td>Finds the Dataverse component and adds it to the Power Platform solution export path.</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <div class="footer"><strong>Built by the FastTrack team. Inspired by the community.</strong> <span>·</span> <a href="https://github.com/microsoft/FastTrack">FastTrack repository</a></div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    const navLinks = Array.from(document.querySelectorAll('.nav-list a'));
+    const sections = navLinks.map((link) => document.querySelector(link.getAttribute('href'))).filter(Boolean);
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        navLinks.forEach((link) => link.classList.toggle('active', link.getAttribute('href') === `#${entry.target.id}`));
+      });
+    }, { rootMargin: '-30% 0px -55% 0px', threshold: 0.1 });
+    sections.forEach((section) => observer.observe(section));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- New: showcase.html inside skill directory — interactive visual guide with workflow diagrams, chat-style examples, gotcha cards, install
- Revamped: copilot-studio-workflow README with compelling pitch, example conversations, badges, and showcase link
- Updated: copilot-agent-samples landing README with 4-category structure (Copilot Studio, Agent Builder, GitHub Copilot Agents, Skills)



