### PR TITLE
fix: use PR + auto-merge for traffic data workflow

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: traffic-data-collection
@@ -185,12 +186,16 @@ jobs:
             --arg date "$DATE" \
             --argjson views "$today_views" \
             --argjson clones "$today_clones" \
+            --argjson referrers "$referrers" \
+            --argjson paths "$paths" \
             '{
               date: $date,
               views_count: ($views.count // 0),
               views_uniques: ($views.uniques // 0),
               clones_count: ($clones.count // 0),
-              clones_uniques: ($clones.uniques // 0)
+              clones_uniques: ($clones.uniques // 0),
+              top_referrers: [($referrers // [])[] | {referrer, count, uniques}],
+              top_paths: [($paths // [])[] | {path, title, count, uniques}]
             }')
 
           if [ -f "$SUMMARY_FILE" ]; then
@@ -207,14 +212,43 @@ jobs:
 
           echo "✅ Updated $SUMMARY_FILE"
 
-      - name: Commit and push
+      - name: Commit and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add traffic-data/
           if git diff --cached --quiet; then
             echo "No changes to commit"
+            exit 0
+          fi
+
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="traffic-data/$DATE"
+
+          # Create a fresh branch and push
+          git checkout -b "$BRANCH"
+          git commit -m "📊 Traffic data for $DATE"
+          git push --set-upstream origin "$BRANCH"
+
+          # Create or update PR (--fill uses commit message as title/body)
+          existing_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing_pr" ]; then
+            echo "PR #$existing_pr already exists for $BRANCH"
           else
-            git commit -m "📊 Traffic data for $(date -u +%Y-%m-%d)"
-            git push
+            gh pr create \
+              --title "📊 Traffic data for $DATE" \
+              --body "Automated daily traffic data collection." \
+              --head "$BRANCH" \
+              --base master
+            echo "✅ PR created"
+          fi
+
+          # Enable auto-merge (requires repo setting "Allow auto-merge" to be on)
+          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$pr_number" ]; then
+            gh pr merge "$pr_number" --auto --squash \
+              && echo "✅ Auto-merge enabled for PR #$pr_number" \
+              || echo "::warning::Could not enable auto-merge — check repo settings"
           fi


### PR DESCRIPTION
- Push to branch + open PR instead of direct push to protected master
- Add pull-requests: write permission for gh pr create/merge
- Enable auto-merge (squash) on traffic data PRs
- Include top_referrers and top_paths in daily summary for view breakdown

