### PR TITLE
docs(copilot-agents-guide): fix declarative agent licensing claim

### DIFF
--- a/copilot-agent-strategy/copilot-agents-guide/index.html
+++ b/copilot-agent-strategy/copilot-agents-guide/index.html
@@ -533,7 +533,7 @@
                 'Inherits M365 Copilot security'
               ],
               limitations: [
-                'Requires Microsoft 365 Copilot license for users',
+                'Users need Microsoft 365 Copilot Chat (included with most M365 subscriptions) — full M365 Copilot license is optional; usage billed via Copilot Credits, or free for M365 Copilot–licensed users',
                 'Limited to Microsoft 365 ecosystem',
                 'Plugin development requires technical skills',
                 'RAI validation checks required for publishing'
@@ -565,7 +565,7 @@
                   'Test with the M365 Copilot orchestrator context in mind — behavior differs from standalone testing'
                 ],
                 deploymentChecklist: [
-                  { item: 'M365 Copilot licenses for all target users', critical: true },
+                  { item: 'Copilot Chat (included with most M365 subscriptions) or M365 Copilot licenses for target users; Copilot Credits configured for Chat users', critical: true },
                   { item: 'Copilot Studio environment provisioned', critical: true },
                   { item: 'Agent instructions and knowledge sources defined', critical: true },
                   { item: 'Plugin actions configured (if needed)', critical: false },


### PR DESCRIPTION
Per MCS CAT blog (https://microsoft.github.io/mcscatblog/posts/no-copilot-license-m365-channel/), declarative agents authored in Copilot Studio do NOT require a full Microsoft 365 Copilot license for end users. Copilot Chat (included with most M365 subscriptions) is sufficient; usage is billed through Copilot Credits, or free for M365 Copilot-licensed users.

- Limitation: 'Requires Microsoft 365 Copilot license for users' ->
  reworded to note Copilot Chat is enough and billing is via Copilot
  Credits (free for M365 Copilot-licensed users).
- Deployment checklist updated to reflect same.



