### PR TITLE
docs: reduce Power BI MCP permissions to 3 (remove Item.Execute.All, …

### DIFF
--- a/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md
+++ b/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md
@@ -79,12 +79,10 @@ It works across four modes:
   | Permission | Description |
   |---|---|
   | `Dataset.Read.All` | View all datasets |
-  | `Item.Execute.All` | Make API calls that require execute permissions on all Fabric items |
   | `MLModel.Execute.All` | Execute ML models |
-  | `SemanticModel.Read.All` | Read semantic models |
   | `Workspace.Read.All` | View all workspaces |
 
-  > ⚠️ All five permissions must have **admin consent granted** (green checkmark in the Status column). Without admin consent, schema retrieval may work but query execution will return 401.
+  > ⚠️ All three permissions must have **admin consent granted** (green checkmark in the Status column). Without admin consent, schema retrieval may work but query execution will return 401.
 - **Power BI admin tenant setting** is enabled: **Users can use the Power BI Model Context Protocol server endpoint (preview)**
 - **Power BI Pro (or higher) license** — the user executing queries must have at least a Pro license and Build permissions on the target semantic model. No Premium capacity or PPU is required for schema retrieval or query execution. The **GenerateQuery** tool requires **Fabric capacity (F2+)** on the workspace.
 - Relevant **Power BI semantic models** exist and are accessible to the signed-in user
@@ -99,8 +97,8 @@ It works across four modes:
 3. Set **Supported account types** to **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**.
 4. Add the Copilot Studio redirect URI as a **Web** platform redirect URI. Do **not** register it under **Single-page application** or **Mobile and desktop applications**.
 5. After creation, go to **API permissions** → **Add a permission** → **Power BI Service** → **Delegated permissions**.
-6. Add all five permissions: **`Dataset.Read.All`**, **`Item.Execute.All`**, **`MLModel.Execute.All`**, **`SemanticModel.Read.All`**, **`Workspace.Read.All`**.
-7. Click **Grant admin consent for [your tenant]** — all five must show a green checkmark.
+6. Add all three permissions: **`Dataset.Read.All`**, **`MLModel.Execute.All`**, **`Workspace.Read.All`**.
+7. Click **Grant admin consent for [your tenant]** — all three must show a green checkmark.
 8. In **Authentication**, leave **Allow public client flows** **Disabled**. Leave both **Implicit grant and hybrid flows** checkboxes unchecked for this setup.
 9. Go to **Certificates & secrets** and create a **client secret**. Save the secret value securely.
 10. Record the **Application (client) ID**, **Directory (tenant) ID**, and secret for Copilot Studio setup.
@@ -122,7 +120,7 @@ It works across four modes:
    - **Authorization URL:** `https://login.microsoftonline.com/common/oauth2/v2.0/authorize`
    - **Token URL:** `https://login.microsoftonline.com/common/oauth2/v2.0/token`
    - **Refresh URL:** `https://login.microsoftonline.com/common/oauth2/v2.0/token`
-   - **Scope:** `https://analysis.windows.net/powerbi/api/Dataset.Read.All https://analysis.windows.net/powerbi/api/Item.Execute.All https://analysis.windows.net/powerbi/api/MLModel.Execute.All https://analysis.windows.net/powerbi/api/SemanticModel.Read.All https://analysis.windows.net/powerbi/api/Workspace.Read.All offline_access`
+   - **Scope:** `https://analysis.windows.net/powerbi/api/Dataset.Read.All https://analysis.windows.net/powerbi/api/MLModel.Execute.All https://analysis.windows.net/powerbi/api/Workspace.Read.All offline_access`
      > ⚠️ Enter all scopes on **one line**, separated by spaces. Do not use line breaks or commas.
      >
      > `offline_access` belongs in the **Scope** field above. Do **not** add it as a separate Power BI API permission in Entra.
@@ -258,7 +256,7 @@ Example autonomous pattern:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Schema works but ExecuteQuery returns 401 | Missing API permissions or admin consent not granted | Verify all 5 Power BI Service permissions are added **and** admin consent is granted (green checkmark). Delete and re-create the Copilot Studio connection after fixing. |
+| Schema works but ExecuteQuery returns 401 | Missing API permissions or admin consent not granted | Verify all 3 Power BI Service permissions are added **and** admin consent is granted (green checkmark). Delete and re-create the Copilot Studio connection after fixing. |
 | Connection goes stale after ~1 hour | Using `.default` scope instead of explicit scopes | Use the explicit scopes listed in Step 3, including `offline_access`. Do **not** use `.default`. |
 | Connection authenticates but later won't refresh | Redirect URI registered under **SPA** or **Mobile/Desktop** instead of **Web** | Re-add the Copilot Studio redirect URI under **Authentication** → **Web**, keep **Allow public client flows** **Disabled**, and re-create the Copilot Studio connection. |
 | Connection fails during OAuth | App not configured as multi-tenant | Set Supported account types to "Accounts in any organizational directory" in the Entra app registration. |


### PR DESCRIPTION
…SemanticModel.Read.All)

Confirmed with PM that only Dataset.Read.All, MLModel.Execute.All, and Workspace.Read.All are required. Updated prerequisites, setup steps, scope string, and troubleshooting references.


