### PR TITLE
Switch to TRAFFIC_TOKEN PAT for PR creation in workflows + Update Agent Cost Calculator

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Commit and open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update-message-center.yml
+++ b/.github/workflows/update-message-center.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-message-center:
@@ -29,11 +30,39 @@ jobs:
         run: |
           git diff --quiet copilot-agent-strategy/copilot-agents-guide/index.html && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push updates
+      - name: Commit and open PR
         if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add copilot-agent-strategy/copilot-agents-guide/index.html
-          git commit -m "chore: weekly message center posts refresh $(date +%Y-%m-%d)"
-          git push
+
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="message-center/$DATE"
+
+          git checkout -b "$BRANCH"
+          git commit -m "chore: weekly message center posts refresh $DATE"
+          git push --set-upstream origin "$BRANCH"
+
+          # Create PR if one doesn't already exist
+          existing_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing_pr" ]; then
+            echo "PR #$existing_pr already exists for $BRANCH"
+          else
+            gh pr create \
+              --title "chore: weekly message center posts refresh $DATE" \
+              --body "Automated weekly message center data update." \
+              --head "$BRANCH" \
+              --base master
+            echo "✅ PR created"
+          fi
+
+          # Enable auto-merge
+          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$pr_number" ]; then
+            gh pr merge "$pr_number" --auto --squash \
+              && echo "✅ Auto-merge enabled for PR #$pr_number" \
+              || echo "::warning::Could not enable auto-merge — check repo settings"
+          fi

--- a/copilot-agent-strategy/copilot-agents-cost-tool/GUIDE.md
+++ b/copilot-agent-strategy/copilot-agents-cost-tool/GUIDE.md
@@ -1,6 +1,6 @@
 # M365 Copilot Agents Cost Calculator — Walk-Through Guide
 
-> Open `index.html` in any modern browser (Edge, Chrome, Firefox). No account, server, or login required.
+> Open `AgentCosTest.html` in any modern browser (Edge, Chrome, Firefox). No account, server, or login required.
 
 ---
 
@@ -31,7 +31,7 @@ Think of it like a flight-price estimator: the final fare depends on fuel surcha
 
 ## 5-Minute Quick Start (for anyone)
 
-1. Open `index.html` in a browser.
+1. Open `AgentCosTest.html` in a browser.
 2. At the top, pick a **Quick start template** from the drop-down (for example, *Enterprise FAQ agent*).
 3. Scroll to the bottom — you will see an **Example Prompt & Cost Trace** and a **Production Cost Estimate** panel filled in automatically.
 4. Adjust any number that doesn't match your real situation. The estimate refreshes instantly.
@@ -81,6 +81,8 @@ The **⟳ Start Over** button resets everything to defaults.
 | Enterprise FAQ agent | Internal FAQ scenarios using SharePoint + enterprise connectors |
 | HR policy agent | Pure internal knowledge (SharePoint, uploaded files) |
 | IT helpdesk with tools + flows | Complex agents with tool calls and automated flows |
+| Employee Self-Service — HR agent starter | ServiceNow HRSD + Workday HR scenarios; shared orchestrator flow; mixed M365 Copilot user share |
+| Employee Self-Service — IT agent starter | ServiceNow ITSM + Microsoft Self-Help; reasoning model for diagnostic classification |
 | General purpose assistant (GPT-4o) | Foundry agents answering questions from uploaded files |
 | Code assistant (GPT-4.1) | Foundry agents doing code review / generation |
 
@@ -174,18 +176,27 @@ This is where you describe what actually happens during a conversation — not w
 | **Distinct test scenarios** | The number of unique conversation scripts or test cases |
 | **Iterations per scenario** | How many times you run each script (for consistency testing) |
 | **Monthly prepaid credits** | Your tenant's monthly credit allowance (0 = not using prepaid) |
-| **Pricing model** | Pay-as-you-go ($0.01/credit) or Prepaid pack ($0.008/credit) |
+| **Pricing model** | Pay-as-you-go, Copilot Credit pack, Copilot Credit P3, or Microsoft Agent P3 (see below) |
 | **% users with M365 Copilot license** | If some users have M365 Copilot licenses, their interactions cost **zero credits** |
 
 **Total test conversations** = Scenarios × Iterations.
 
-**Prepaid vs. Pay-as-you-go**:
-- Pay-as-you-go: $0.01 per credit, billed through Azure.
-- Prepaid pack: $200 for 25 000 credits ($0.008/credit — 20% cheaper).
+**Pricing model options** (all bill in Copilot Credits — only the dollar conversion changes):
+
+| Option | Effective $/credit | Best for |
+|---|---|---|
+| **Pay-as-you-go (PAYG) meter** | $0.0100 | Postpaid via Azure, no commitment |
+| **Copilot Credit pack** (subscription) | $0.0080 | Predictable monthly use; $200/25,000 credits |
+| **Copilot Credit Pre-Purchase Plan (P3)** | $0.0095 → $0.0080 | 1-year commit, 9 tiers (5–20% off) |
+| **Microsoft Agent Pre-Purchase Plan (P3)** *(NEW May 2026)* | $0.0095 / $0.0090 / $0.0085 | 1-year commit covering **both** Copilot Studio AND Microsoft Foundry usage; 3 tiers (5/10/15% off) |
+
+Source: [Microsoft Copilot Studio Licensing Guide — May 2026 (PDF)](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/bizapps/Microsoft-Copilot-Studio-Licensing-Guide-May-2026-PUB.pdf).
 
 **M365 Copilot license impact**: If 50% of your users have M365 Copilot licenses, half of all interactions are free. The "% users with M365 Copilot license" field accounts for this in the estimate.
 
-**Capacity overage**: If prepaid credits are configured, the tool shows a capacity bar. At **125% of prepaid**, custom agents are disabled by the platform. The bar turns yellow at 80% and red at 100%.
+**Capacity overage**: If prepaid credits are configured, the tool shows a capacity bar. At **125% of prepaid**, custom agents are disabled by the platform.
+
+> **Voice agents** *(introduced in the May 2026 Licensing Guide)* are billed by **total call length to the nearest second** plus the configured voice orchestration. Voice agents are **not modeled** in this tool — estimate them separately.
 
 ---
 
@@ -232,7 +243,7 @@ That is a *Tool / Connector call* turn. In Step 3, set "Tool / Connector calls" 
 Use the "% users with M365 Copilot license" field in Step 4. Users with those licenses consume zero credits for all features.
 
 ### "We haven't decided on a pricing model yet"
-Try both. Change the "Pricing model" in Step 4 between Pay-as-you-go and Prepaid pack. The credit count stays the same; only the dollar total changes.
+Try all four. Change the "Pricing model" in Step 4 between Pay-as-you-go, Copilot Credit pack, Copilot Credit P3 (9 tiers), and Microsoft Agent P3 (3 tiers, NEW May 2026 — covers Copilot Studio + Foundry). The credit count stays the same; only the dollar total changes.
 
 ### "The agent reads from multiple SharePoint sites"
 Check **SharePoint / OneDrive** in Step 1 and set the number of sites for reference. The credit cost per lookup is still 12 credits (with graph) regardless of how many sites — the per-query cost comes from Step 3's knowledge lookup turns, not Step 1's source count.

--- a/copilot-agent-strategy/copilot-agents-cost-tool/README.md
+++ b/copilot-agent-strategy/copilot-agents-cost-tool/README.md
@@ -1,91 +1,383 @@
-# Microsoft FastTrack Open Source - M365 Copilot Agents Cost Calculator
+# M365 Copilot Agents Cost Calculator
 
-An interactive, browser-based calculator that helps you estimate production costs for Microsoft 365 Copilot agents — including Custom Agents (Copilot Studio), Agent Builder (M365 Copilot), SharePoint Agents, and Azure Foundry Agents — before you deploy them.
+A self-contained, browser-based cost estimator for Microsoft 365 Copilot agents.
+Open `AgentCosTest.html` in any modern browser — no server, no dependencies, no login required.
 
-> **⚠️ Important:** This tool produces **planning estimates only**. It is not a billing commitment, a contractual obligation, or a guarantee of any kind. Actual charges will vary based on runtime behavior, tenant configuration, model usage, and current Microsoft pricing. See the [full disclaimer](#legal--disclaimer-notice) below.
+> **This tool produces planning estimates only. Results are not a billing commitment.**
+> Actual charges depend on runtime behavior, orchestration paths, tenant configuration,
+> model usage, Microsoft licensing changes, and feature availability.
 
-## Usage
+---
 
-### Quick Start
+## What it covers
 
-1. Open [`index.html`](./index.html) in any modern browser (Edge, Chrome, Firefox) — no account, server, or login required
-2. Pick a **Quick Start Template** from the drop-down (e.g., *Enterprise FAQ agent*)
-3. Scroll to the bottom to see the **Example Prompt & Cost Trace** and **Production Cost Estimate**
-4. Adjust any numbers to match your scenario — the estimate refreshes instantly
-5. Click **Export CSV** or **Print** to save results
+| Agent type | Billing model |
+|---|---|
+| **Custom agent** (Copilot Studio) | Copilot Credits — per classic answer, generative answer, agent action, graph grounding, AI prompt, agent flow, content processing |
+| **Agent Builder agent** (M365 Copilot declarative) | Copilot Credits — knowledge sources only; public website grounding is free |
+| **SharePoint agent** | Copilot Credits — SharePoint via tenant graph grounding |
+| **Foundry agent** (Azure AI Foundry Agent Service) | Token-based — input + output tokens billed to Azure subscription; no Copilot Credits |
 
-### Hosted Version
+---
 
-The calculator is also available via GitHub Pages at:
+## How to use
 
-`https://microsoft.github.io/FastTrack/copilot-agent-strategy/copilot-agents-cost-tool/`
+1. Open `AgentCosTest.html` in a browser.
+2. **Select your agent type** at the top.
+3. (Optional) **Pick a quick-start template** to pre-fill a realistic enterprise scenario.
+4. Fill in the steps:
+   - **Knowledge sources** — which sources your agent uses and how many.
+   - **Components** (custom agents) — topics, tools, AI prompts, flows.
+   - **Conversation profile** — how many turns per conversation and what happens in each.
+   - **Test plan scale** — number of scenarios × iterations.
+   - **Foundry agents** — model, token sizes, turns, and built-in tools (File Search, Code Interpreter).
+5. Review the **Example Prompt & Cost Trace** to validate the per-turn breakdown.
+6. Review the **Production Cost Estimate** panel for totals, a credit breakdown chart, and capacity impact.
+7. Use **Export CSV** to save the configuration and results, or **Print** for a shareable snapshot.
+8. Click **Start Over** (header or results panel) to reset everything.
 
-### Features
+---
 
-- **4 agent types**: Custom Agent (Copilot Studio), Agent Builder (M365 Copilot), SharePoint Agent, Azure Foundry Agent
-- **Quick start templates**: Enterprise FAQ, HR Policy, IT Helpdesk with tools + flows, General Purpose (GPT-4o), Code Assistant (GPT-4.1)
-- **12 Azure OpenAI models**: GPT-4o family, GPT-4.1 family, GPT-5 family (incl. nano, 5.1, 5.2, 5.3), o3, o4-mini
-- **Full cost modeling**: Knowledge sources, tools/connectors, AI prompts, agent flows, reasoning models, content processing
-- **Copilot Credits & Azure tokens**: Models both billing systems depending on agent type
-- **Capacity tracking**: Prepaid vs. pay-as-you-go comparison with overage visualization
-- **M365 Copilot license impact**: Accounts for licensed users whose interactions cost zero credits
-- **Export**: CSV export and print-friendly PDF output
-- **Dark/light theme**: Toggle between themes
+## Quick-start templates
 
-### Walk-Through Guide
+| Template | Agent type | What it models |
+|---|---|---|
+| Enterprise FAQ agent | Custom (Copilot Studio) | SharePoint + enterprise connectors, authored topics, no tools or flows |
+| HR policy agent | Custom (Copilot Studio) | SharePoint, connectors, uploaded files, pure internal knowledge — no tools, flows, or AI prompts |
+| IT helpdesk with tools + flows | Custom (Copilot Studio) | SharePoint, connectors, tools, agent flow, AI prompts, reasoning model |
+| Employee Self-Service — HR agent starter | Custom (Copilot Studio) | SharePoint HR policies + ServiceNow Knowledge KB + Workday connector; HRSD topics for create/get/update HR cases; shared orchestrator flow; no reasoning; 70% M365 user share |
+| Employee Self-Service — IT agent starter | Custom (Copilot Studio) | SharePoint IT docs + ServiceNow Knowledge KB + Microsoft Self-Help connector; ITSM topics for create/get/update tickets; reasoning model for diagnostic classification; 50% M365 user share |
+| General purpose assistant (GPT-4o) | Foundry agent | GPT-4o, 5 turns with file search, token-based billing |
+| Code assistant (GPT-4.1) | Foundry agent | GPT-4.1, 6 turns with code interpreter, token-based billing |
 
-For a detailed step-by-step guide covering every section of the calculator, see [GUIDE.md](./GUIDE.md).
+---
 
-## Applies To
+## What makes this tool different from Microsoft's official estimator
 
-- Microsoft 365 Copilot
-- Microsoft Copilot Studio
-- Azure AI Foundry Agent Service
-- Microsoft 365 Copilot Agent Builder
+Microsoft provides the [Copilot Studio agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/) for Copilot Credits forecasting.
+Here is what this tool covers that theirs does not:
 
-## Author
+| Capability | This tool | Microsoft's estimator |
+|---|---|---|
+| Azure Foundry / token-based agents | **Yes** | No |
+| Per-turn cost trace with credit breakdown | **Yes** | No |
+| Dollar cost display (not just credits) | **Yes** | Credits only |
+| SharePoint / Agent Builder agent types | **Yes** | No |
+| Quick-start templates (pre-filled configs) | **Yes** | Category filter only |
+| Reasoning model surcharge modelled | **Yes** | Not explicit |
+| CSV export + Print snapshot | **Yes** | Download results |
+| Pay-as-you-go vs Credit pack vs CC P3 vs Agent P3 comparison | **Yes** *(all 4 plans incl. May 2026 Agent P3)* | No |
 
-|Author|Original Publish Date
-|----|--------------------------
-|[Georgi Nunev](mailto:Georgi.Nunev@microsoft.com)|April 2025|
+---
 
-## Reference Links
+## Billing rates reference
 
-- [Copilot Credits billing rates (Microsoft Learn)](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#copilot-credits-billing-rates)
-- [Reasoning model billing (Microsoft Learn)](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#reasoning-model-billing-rates)
-- [Cost considerations for extensibility (Microsoft Learn)](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/cost-considerations)
-- [Foundry Agent Service overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/foundry/agents/overview)
-- [Azure OpenAI pricing (azure.microsoft.com)](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/)
+### Copilot Studio / M365 Copilot agents
 
-## Issues
+Source: [Copilot Credits billing rates (Microsoft Learn)](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#copilot-credits-billing-rates)
 
-Please report any issues you find to the [issues list](https://github.com/Microsoft/FastTrack/issues).
+| Feature | Credits | Unit |
+|---|---|---|
+| Classic answer | 1 | per response |
+| Generative answer | 2 | per response |
+| Agent action (tool call, flow trigger) | 5 | per action |
+| Tenant graph grounding | 10 | per message |
+| SharePoint or connector (graph-grounded) | 12 | per query (10 graph + 2 gen) |
+| Agent flow actions | 13 | per 100 actions |
+| AI tools — basic | 1 | per 10 responses |
+| AI tools — standard | 15 | per 10 responses |
+| AI tools — premium | 100 | per 10 responses |
+| Content processing | 8 | per page |
+| Reasoning model surcharge | +10 | per generative answer and agent action |
 
-## Legal & Disclaimer Notice
+**Pricing options** (all bill in Copilot Credits):
 
-This tool is provided for **planning and estimation purposes only**. It does not constitute a contract, quote, invoice, or billing commitment of any kind. Microsoft's actual pricing, licensing terms, and billing behavior are governed solely by the applicable Microsoft Customer Agreement, Product Terms, and the Azure pricing pages in effect at the time of use.
+| Option | Effective $/credit | Notes |
+|---|---|---|
+| Pay-as-you-go (PAYG) meter | $0.0100 | Postpaid; billed via Azure subscription. No commitment. |
+| Copilot Credit pack (subscription) | $0.0080 | $200/month for 25,000 credits. Unused credits do not roll over. |
+| Copilot Credit Pre-Purchase Plan (P3) | $0.0095 → $0.0080 | 1-year commit, 9 tiers, 5% → 20% discount (3,000 → 3,000,000 CCCUs). 1 CCCU = 100 credits. |
+| **Microsoft Agent Pre-Purchase Plan (P3)** *(NEW May 2026)* | $0.0095 / $0.0090 / $0.0085 | 1-year commit, 3 tiers, 5% / 10% / 15%. **Covers BOTH Copilot Studio AND Microsoft Foundry usage.** 1 ACU = 100 credits or $1 Foundry. |
 
-Pricing rates used in this calculator were sourced from Microsoft Learn documentation and Azure pricing pages. Rates are subject to change without notice. Always verify current rates at:
-- [Copilot Credits billing rates](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#copilot-credits-billing-rates)
-- [Azure OpenAI pricing](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/)
+Source: [Microsoft Copilot Studio Licensing Guide (May 2026)](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/bizapps/Microsoft-Copilot-Studio-Licensing-Guide-May-2026-PUB.pdf).
 
-## Support Statement
+**M365 Copilot licensed users** consume zero credits for all features when operating under their authenticated M365 Copilot identity (subject to fair-use limits).
 
-The scripts, samples, and tools made available through the FastTrack Open Source initiative are provided as-is. These resources are developed in partnership with the community and do not represent official Microsoft software. As such, support is not available through premier or other Microsoft support channels. If you find an issue or have questions please reach out through the issues list and we'll do our best to assist, however there is no associated SLA.
+**Voice agents** (introduced in the May 2026 Licensing Guide) are billed by **total call length to the nearest second** plus the configured voice orchestration. Voice agents are **not modeled** in this tool — estimate them separately.
 
-## Code of Conduct
+**Agent Builder and SharePoint agents** using pay-as-you-go: billing is configured in the Microsoft 365 admin center and billed to the linked Azure subscription under Microsoft 365 Copilot pay-as-you-go — not Copilot Studio meters.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+### Azure Foundry agents
 
-## Legal Notices
+Source: [Azure OpenAI pricing](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/) · [Foundry Agent Service overview](https://learn.microsoft.com/en-us/azure/foundry/agents/overview)
 
-Microsoft and any contributors grant you a license to the Microsoft documentation and other content in this repository under the [MIT License](https://opensource.org/licenses/MIT), see the [LICENSE](LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the [LICENSE-CODE](LICENSE-CODE) file.
+Billed by tokens (input + output) to your Azure subscription. Context accumulates each turn — every user message re-sends the full conversation history as input, so costs grow with conversation length.
 
-Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries. The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks. Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+Selected models (Global Standard pay-as-you-go, USD / 1M tokens):
 
-Privacy information can be found at https://privacy.microsoft.com/en-us/
+| Model | Input | Output |
+|---|---|---|
+| GPT-4.1-nano | $0.10 | $0.40 |
+| GPT-4o mini | $0.15 | $0.60 |
+| GPT-5-nano | $0.05 | $0.40 |
+| GPT-5-mini | $0.25 | $2.00 |
+| GPT-5.1-codex-mini | $0.25 | $2.00 |
+| GPT-4.1-mini | $0.40 | $1.60 |
+| GPT-4.1 | $2.00 | $8.00 |
+| GPT-4o (2024-11-20) | $2.50 | $10.00 |
+| o4-mini | $1.10 | $4.40 |
+| o3 | $2.00 | $8.00 |
+| GPT-5 (2025-08-07) | $1.25 | $10.00 |
+| GPT-5.1 | $1.25 | $10.00 |
+| GPT-5.2 | $1.75 | $14.00 |
+| GPT-5.3 | $1.75 | $14.00 |
+| GPT-5.4-nano | $0.20 | $1.25 |
+| GPT-5.4-mini | $0.75 | $4.50 |
+| GPT-5.4 (<272k ctx) | $2.50 | $15.00 |
+| GPT-5.4 Pro (<272k ctx) | $30.00 | $180.00 |
 
-Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
-or trademarks, whether by implication, estoppel or otherwise.
+Built-in tools: File Search $2.50/1K calls · Code Interpreter $0.033/session.
+
+---
+
+## Other resources
+
+- [Microsoft agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/) — for monthly *production* usage forecasting
+- [Overage enforcement](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#overage-enforcement)
+- [Cost considerations for M365 Copilot extensibility](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/cost-considerations)
+- [M365 Copilot pay-as-you-go overview](https://learn.microsoft.com/en-us/copilot/microsoft-365/pay-as-you-go/overview)
+
+
+> **1 Copilot Credit = $0.01 USD**
+
+The [Microsoft agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/) forecasts monthly production usage. This script does the opposite — it calculates the cost of your **test plan** based on individual conversations, so you can budget before you start testing.
+
+---
+
+## Prerequisites
+
+- **PowerShell 7+** (the script uses `#Requires -Version 7.0`)
+  - Check your version: `$PSVersionTable.PSVersion`
+  - If you need to install it: `winget install Microsoft.PowerShell`
+- No modules or authentication required — everything runs locally
+
+---
+
+## Quick Start
+
+### Option A: Interactive Mode (guided prompts)
+
+```powershell
+.\Estimate-CopilotStudioTestCost.ps1
+```
+
+The script will walk you through each test scenario step by step.
+
+### Option B: Batch Mode (from a CSV file)
+
+```powershell
+.\Estimate-CopilotStudioTestCost.ps1 -ScenarioFile .\sample-test-plan.csv -PrepaidCredits 25000
+```
+
+---
+
+## Step-by-Step Guide: Interactive Mode
+
+### Step 1 — Open a terminal and navigate to the script
+
+```powershell
+cd path\to\copilot-studio-test-cost
+```
+
+### Step 2 — Run the script
+
+```powershell
+.\Estimate-CopilotStudioTestCost.ps1
+```
+
+### Step 3 — Enter your prepaid capacity (optional)
+
+The script asks for your monthly prepaid Copilot Credits. This lets it show what percentage of your capacity testing will consume. Enter `0` to skip.
+
+```
+Monthly prepaid Copilot Credits - enter 0 to skip capacity check [0]: 25000
+```
+
+### Step 4 — Define your first test scenario
+
+Give the scenario a descriptive name:
+
+```
+Scenario name: FAQ flow test
+```
+
+### Step 5 — Enter the features used in ONE test conversation
+
+For each feature, enter how many times it fires in a single conversation. Press Enter to accept the default of `0`.
+
+```
+Classic answers [0]: 2
+Generative answers [0]: 3
+Agent actions - triggers / topic transitions / deep reasoning [0]: 1
+Tenant graph grounded messages [0]: 0
+Agent flow actions - note: FREE in test pane [0]: 0
+AI prompt tool calls - basic tier [0]: 0
+AI prompt tool calls - standard tier [0]: 0
+AI prompt tool calls - premium tier [0]: 0
+Content processing pages [0]: 0
+Uses reasoning model? [y/N]: n
+```
+
+> **Tip**: If you're unsure what counts as each feature, open your agent in Copilot Studio, run a test conversation, and check the **activity map** — each step shown there maps to the features above.
+
+### Step 6 — Enter the number of iterations
+
+How many times will this scenario be run? Count all testers and all passes (e.g., 3 testers × 2 passes = 6).
+
+```
+How many times will you run this scenario? [1]: 10
+```
+
+### Step 7 — Add more scenarios or finish
+
+```
+Add another scenario? [y/N]: y
+```
+
+Repeat steps 4–6 for each scenario. When done, enter `n`.
+
+### Step 8 — Review the results
+
+The script outputs a summary with:
+
+- **Per-scenario breakdown** — credits per conversation × iterations
+- **Feature breakdown** — which features drive the most cost
+- **Capacity impact** — percentage of your monthly prepaid credits consumed by testing
+
+---
+
+## Step-by-Step Guide: Batch Mode (CSV)
+
+### Step 1 — Create your test plan CSV
+
+Copy `sample-test-plan.csv` and edit it with your scenarios. The columns are:
+
+| Column | What it means | Example |
+|---|---|---|
+| `ScenarioName` | Description of the test case | `FAQ flow test` |
+| `ClassicAnswers` | Static/authored responses per conversation | `2` |
+| `GenerativeAnswers` | AI-generated responses per conversation | `3` |
+| `AgentActions` | Triggers, topic transitions, deep reasoning steps | `1` |
+| `TenantGraphMessages` | Messages using tenant graph grounding | `0` |
+| `AgentFlowActions` | Flow actions (FREE in test pane — tracked for awareness) | `0` |
+| `BasicPrompts` | Basic-tier AI prompt tool calls | `0` |
+| `StandardPrompts` | Standard-tier AI prompt tool calls | `0` |
+| `PremiumPrompts` | Premium-tier AI prompt tool calls | `0` |
+| `ContentPages` | Pages processed by content processing tools | `0` |
+| `UsesReasoningModel` | `1` if reasoning model is enabled, `0` otherwise | `0` |
+| `Iterations` | Total times this scenario will be run (testers × passes) | `10` |
+
+**Example row:**
+
+```csv
+FAQ flow test,2,3,1,0,0,0,0,0,0,0,10
+```
+
+### Step 2 — Run the script with your CSV
+
+```powershell
+.\Estimate-CopilotStudioTestCost.ps1 -ScenarioFile .\my-test-plan.csv
+```
+
+### Step 3 — Add prepaid capacity (optional)
+
+To see the capacity impact:
+
+```powershell
+.\Estimate-CopilotStudioTestCost.ps1 -ScenarioFile .\my-test-plan.csv -PrepaidCredits 25000
+```
+
+---
+
+## Understanding the Output
+
+```
+===============================================================
+  COPILOT STUDIO - TEST COST ESTIMATE
+===============================================================
+
+  Scenario Breakdown:
+  -------------------------------------------------------------
+  Scenario                       Per Conv  Iter.    Credits        USD
+  -------------------------------------------------------------
+  Greeting and FAQ                      9      5         45      $0.45
+  Knowledge retrieval (ShareP...       16     10        160      $1.60
+  ...
+  TOTAL                                                2072     $20.72
+```
+
+| Column | Meaning |
+|---|---|
+| **Per Conv** | Credits consumed by one execution of the scenario |
+| **Iter.** | Total number of times the scenario runs |
+| **Credits** | Per Conv × Iter. |
+| **USD** | Credits × $0.01 |
+
+The **Credit Breakdown by Feature** section shows which features cost the most — useful for identifying where to optimize.
+
+The **Capacity Impact** section (when you provide `-PrepaidCredits`) shows:
+- What percentage of your monthly allocation testing will use
+- How many credits remain for production
+- The overage enforcement threshold (125% of capacity)
+
+---
+
+## How to Count Features in Your Agent
+
+Not sure what numbers to enter? Here's how to figure it out:
+
+1. **Open your agent** in Copilot Studio
+2. **Run a test conversation** in the test pane
+3. **Check the activity map** — each step maps to a feature:
+
+| What you see in the activity map | Feature to count |
+|---|---|
+| A static, authored response | Classic answer |
+| An AI-generated answer from knowledge | Generative answer |
+| A trigger firing, topic transition, or deep reasoning step | Agent action |
+| A response grounded in Microsoft Graph tenant data | Tenant graph grounding |
+| A flow executing a sequence of steps | Agent flow action (free in test pane) |
+| A prompt tool running (check the tier in Prompt Builder) | Basic / Standard / Premium prompt |
+| Document/image processing | Content processing (per page) |
+
+4. **Check if reasoning is enabled** — in your agent's model settings, if a reasoning-capable model is selected, set `UsesReasoningModel` to `1`
+
+---
+
+## Billing Rates Reference
+
+Source: [Copilot Credits billing rates](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#copilot-credits-billing-rates)
+
+| Feature | Credits | Unit | Free in Test Pane? |
+|---|---|---|---|
+| Classic answer | 1 | per response | No |
+| Generative answer | 2 | per response | No |
+| Agent action | 5 | per action | No |
+| Tenant graph grounding | 10 | per message | No |
+| Agent flow actions | 13 | per 100 actions | **Yes** |
+| AI tools (basic) | 1 | per 10 responses | No |
+| AI tools (standard) | 15 | per 10 responses | No |
+| AI tools (premium) | 100 | per 10 responses | No |
+| Content processing | 8 | per page | No |
+
+**Reasoning model surcharge**: When enabled, adds 10 credits per generative answer response (100 credits / 10 responses) on top of the base rate.
+
+---
+
+## Tips to Reduce Test Costs
+
+- **Start without tenant graph grounding** — at 10 credits/message, it's the most expensive per-unit feature. Test your agent's core logic first, then enable graph grounding for a final validation pass.
+- **Test with standard models first** — if your agent uses a reasoning model, switch to standard for initial testing (2 credits vs 12 credits per generative answer). Use reasoning only for final QA.
+- **Prioritize critical paths** — don't iterate every scenario equally. Run edge cases 2–3 times, but run your happy path and critical flows more.
+- **Leverage free flow testing** — agent flow actions don't consume credits in the test pane, so test flows thoroughly before publishing.
+- **Combine similar scenarios** — if two test cases exercise the same features, merge them to reduce overhead.

--- a/copilot-agent-strategy/copilot-agents-cost-tool/index.html
+++ b/copilot-agent-strategy/copilot-agents-cost-tool/index.html
@@ -523,6 +523,8 @@
               <option value="faq">Enterprise FAQ agent</option>
               <option value="hr">HR policy agent (internal knowledge)</option>
               <option value="it">IT helpdesk with tools + flows</option>
+              <option value="ess_hr">Employee Self-Service — HR agent starter (ServiceNow HRSD + Workday)</option>
+              <option value="ess_it">Employee Self-Service — IT agent starter (ServiceNow ITSM + Self-Help)</option>
             </optgroup>
             <optgroup label="Azure Foundry agents">
               <option value="foundry_general">General purpose assistant (GPT-4o)</option>
@@ -581,12 +583,14 @@
               <span class="tooltip">
                 Choose the language model your Foundry agent uses. This sets the token price.<br><br>
                 <strong>Global Standard pay-as-you-go (USD / 1M tokens):</strong><br>
+                &bull; GPT-5.4-nano: $0.20 in / $1.25 out<br>
                 &bull; GPT-4.1-nano: $0.10 in / $0.40 out<br>
                 &bull; GPT-4o mini: $0.15 in / $0.60 out<br>
                 &bull; GPT-5-nano: $0.05 in / $0.40 out<br>
                 &bull; GPT-5-mini: $0.25 in / $2.00 out<br>
                 &bull; GPT-5.1-codex-mini: $0.25 in / $2.00 out<br>
                 &bull; GPT-4.1-mini: $0.40 in / $1.60 out<br>
+                &bull; GPT-5.4-mini: $0.75 in / $4.50 out<br>
                 &bull; GPT-4.1: $2.00 in / $8.00 out<br>
                 &bull; GPT-4o: $2.50 in / $10.00 out<br>
                 &bull; o4-mini: $1.10 in / $4.40 out<br>
@@ -594,7 +598,10 @@
                 &bull; GPT-5: $1.25 in / $10.00 out<br>
                 &bull; GPT-5.1: $1.25 in / $10.00 out<br>
                 &bull; GPT-5.2: $1.75 in / $14.00 out<br>
-                &bull; GPT-5.3: $1.75 in / $14.00 out<br><br>
+                &bull; GPT-5.3: $1.75 in / $14.00 out<br>
+                &bull; GPT-5.4 (&lt;272k ctx): $2.50 in / $15.00 out<br>
+                &bull; GPT-5.4 Pro (&lt;272k ctx): $30.00 in / $180.00 out<br><br>
+                Long-context (&gt;272k) and Data Zone variants are priced higher — see full Azure OpenAI pricing.<br><br>
                 <a href="https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/" target="_blank" rel="noopener noreferrer">Full Azure OpenAI pricing &rarr;</a>
               </span>
             </button>
@@ -612,6 +619,10 @@
             <option value="gpt5_1">GPT-5.1 &mdash; $1.25 / $10.00 per 1M tokens</option>
             <option value="gpt5_2">GPT-5.2 &mdash; $1.75 / $14.00 per 1M tokens</option>
             <option value="gpt5_3">GPT-5.3 &mdash; $1.75 / $14.00 per 1M tokens</option>
+            <option value="gpt5_4_nano">GPT-5.4-nano &mdash; $0.20 / $1.25 per 1M tokens</option>
+            <option value="gpt5_4_mini">GPT-5.4-mini &mdash; $0.75 / $4.50 per 1M tokens</option>
+            <option value="gpt5_4">GPT-5.4 (&lt;272k ctx) &mdash; $2.50 / $15.00 per 1M tokens</option>
+            <option value="gpt5_4_pro">GPT-5.4 Pro (&lt;272k ctx) &mdash; $30.00 / $180.00 per 1M tokens</option>
             <option value="o4_mini">o4-mini &mdash; $1.10 / $4.40 per 1M tokens</option>
             <option value="o3">o3 &mdash; $2.00 / $8.00 per 1M tokens</option>
           </select>
@@ -1203,15 +1214,34 @@
             <button class="info-btn" aria-label="Info about pricing model">i
               <span class="tooltip">
                 <strong>Pay-as-you-go (PAYG)</strong>: $0.01 per credit. Billed via Azure subscription.<br>
-                <strong>Prepaid pack</strong>: $200 for 25,000 credits = $0.008/credit (20% cheaper).<br>
+                <strong>Copilot Credit pack</strong> (monthly subscription): $200 for 25,000 credits = $0.008/credit (20% cheaper).<br>
+                <strong>Copilot Credit Pre-Purchase Plan (P3)</strong>: 1-year up-front commitment in CCCUs (1 CCCU = $1 = 100 credits). 9 tiers from 5% (3,000 CCCUs) to 20% (3,000,000 CCCUs).<br>
+                <strong>Microsoft Agent Pre-Purchase Plan (P3)</strong>: NEW May 2026 — unified 1-year commit in ACUs (1 ACU = $1 = 100 credits). Covers BOTH Copilot Studio AND Microsoft Foundry usage. 3 tiers: 5% / 10% / 15%.<br>
                 This affects only the dollar estimate — credit counts are the same either way.<br><br>
-                <a href="https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management" target="_blank" rel="noopener noreferrer">Billing rates &rarr;</a>
+                <a href="https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management" target="_blank" rel="noopener noreferrer">Billing rates &rarr;</a><br>
+                <a href="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/bizapps/Microsoft-Copilot-Studio-Licensing-Guide-May-2026-PUB.pdf" target="_blank" rel="noopener noreferrer">Copilot Studio Licensing Guide (May 2026) &rarr;</a>
               </span>
             </button>
           </label>
           <select id="scale_pricingModel" onchange="recalculate()">
             <option value="payg" selected>Pay-as-you-go ($0.01 / credit)</option>
-            <option value="prepaid">Prepaid pack ($0.008 / credit)</option>
+            <option value="prepaid">Copilot Credit pack — $200/25,000 credits ($0.008 / credit, 20% off)</option>
+            <optgroup label="Copilot Credit Pre-Purchase Plan (P3) — 1-year commit">
+              <option value="ccp3_t1">CC P3 Tier 1 — 3,000 CCCUs ($2,850, 5% off, $0.0095/cr)</option>
+              <option value="ccp3_t2">CC P3 Tier 2 — 15,000 CCCUs ($14,100, 6% off, $0.0094/cr)</option>
+              <option value="ccp3_t3">CC P3 Tier 3 — 30,000 CCCUs ($27,900, 7% off, $0.0093/cr)</option>
+              <option value="ccp3_t4">CC P3 Tier 4 — 150,000 CCCUs ($138,000, 8% off, $0.0092/cr)</option>
+              <option value="ccp3_t5">CC P3 Tier 5 — 300,000 CCCUs ($270,000, 10% off, $0.0090/cr)</option>
+              <option value="ccp3_t6">CC P3 Tier 6 — 750,000 CCCUs ($660,000, 12% off, $0.0088/cr)</option>
+              <option value="ccp3_t7">CC P3 Tier 7 — 1,500,000 CCCUs ($1,290,000, 14% off, $0.0086/cr)</option>
+              <option value="ccp3_t8">CC P3 Tier 8 — 2,250,000 CCCUs ($1,867,500, 17% off, $0.0083/cr)</option>
+              <option value="ccp3_t9">CC P3 Tier 9 — 3,000,000 CCCUs ($2,400,000, 20% off, $0.0080/cr)</option>
+            </optgroup>
+            <optgroup label="Microsoft Agent Pre-Purchase Plan (P3) — NEW May 2026 (covers MCS + Foundry)">
+              <option value="ap3_t1">Agent P3 Tier 1 — 20,000 ACUs ($19,000, 5% off, $0.0095/cr)</option>
+              <option value="ap3_t2">Agent P3 Tier 2 — 100,000 ACUs ($90,000, 10% off, $0.0090/cr)</option>
+              <option value="ap3_t3">Agent P3 Tier 3 — 500,000 ACUs ($425,000, 15% off, $0.0085/cr)</option>
+            </optgroup>
           </select>
         </div>
         <div class="field" id="scale_m365_row">
@@ -1275,23 +1305,44 @@
       <a href="https://learn.microsoft.com/en-us/azure/foundry/agents/overview" target="_blank" rel="noopener noreferrer">
         Foundry Agent Service
       </a>
-      &nbsp;|&nbsp; Last verified: April 2026
+      &nbsp;|&nbsp;
+      <a href="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/bizapps/Microsoft-Copilot-Studio-Licensing-Guide-May-2026-PUB.pdf" target="_blank" rel="noopener noreferrer">
+        Copilot Studio Licensing Guide (May 2026)
+      </a>
+      &nbsp;|&nbsp; Last verified: May 2026
     </p>
-    <span class="version-badge" id="versionBadge">v1.4.0</span>
+    <span class="version-badge" id="versionBadge">v1.6.1</span>
   </div>
 </div>
 
 <script>
 /* ═══════════════════════════════════════
-   Billing rates (verified against Microsoft Learn 04/2026)
+   Copilot Credits billing rates (verified against Microsoft Learn 05/2026 —
+   page last updated 03/20/2026 — and the Copilot Studio Licensing Guide,
+   May 2026 edition. All Copilot Credits feature rates unchanged since v1.4.0.
+   v1.6.0 added Copilot Credit P3 + Microsoft Agent P3 plans + voice-agent
+   callout. v1.6.1 polish: linkified footer reference to the Licensing Guide,
+   expanded ESS template names to "Employee Self-Service".)
    https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management
    ═══════════════════════════════════════ */
 const CREDIT_TO_USD_PAYG = 0.01;
-const CREDIT_TO_USD_PREPAID = 0.008; // $200 / 25,000 credits
+const CREDIT_TO_USD_PREPAID = 0.008; // Copilot Credit pack: $200 / 25,000 credits
 const REASONING_SURCHARGE = 10; // premium AI tools: 100 credits / 10 responses
 const CONTENT_PROCESSING_RATE = 8; // 8 credits per page
 const PROMPT_RATES = { basic: 1/10, standard: 15/10, premium: 100/10 };
-const APP_VERSION = 'v1.4.0';
+/* Pre-purchase plan effective $/credit. Both CCCU and ACU = $1 list = 100 credits.
+   Effective $/credit = (Tier price / Tier units) / 100. */
+const PRICING_MODEL_RATES = {
+  payg:    CREDIT_TO_USD_PAYG,
+  prepaid: CREDIT_TO_USD_PREPAID,
+  // Copilot Credit Pre-Purchase Plan (P3) — 9 tiers, Feb 2026
+  ccp3_t1: 0.00950, ccp3_t2: 0.00940, ccp3_t3: 0.00930, ccp3_t4: 0.00920,
+  ccp3_t5: 0.00900, ccp3_t6: 0.00880, ccp3_t7: 0.00860, ccp3_t8: 0.00830,
+  ccp3_t9: 0.00800,
+  // Microsoft Agent Pre-Purchase Plan (P3) — NEW May 2026 — covers MCS + Foundry
+  ap3_t1:  0.00950, ap3_t2:  0.00900, ap3_t3:  0.00850,
+};
+const APP_VERSION = 'v1.6.1';
 const TEMPLATES = {
   faq: {
     label: 'Enterprise FAQ agent',
@@ -1433,26 +1484,146 @@ const TEMPLATES = {
         'Submit the privileged access request workflow.'
       ]
     }
+  },
+  ess_hr: {
+    label: 'Employee Self-Service — HR agent starter (ServiceNow HRSD + Workday)',
+    agentType: 'custom',
+    /* Knowledge: SharePoint HR policies + ServiceNow Knowledge KB (M365 Copilot Connector)
+       Connector data: Workday HCM/Absence/Payroll via SOAP RaaS connector */
+    ks: { sharepoint: 3, connectors: 2 },
+    sharepointGraph: true,
+    classicTopics: 2,   /* Conversation Start + [Example] Sensitive Topics (handoff) */
+    tools: 4,           /* HRSD: Create Case, Get Case Details, Get Case Updates, Get User Cases */
+    prompts: 1,
+    promptTier: 'standard',
+    flows: 1,           /* HRSD Common Orchestrator (shared flow pattern) */
+    flowActions: 18,    /* HRSD orchestrator chains: create + list + get + cache steps */
+    contentPages: 0,
+    reasoning: false,
+    knowledgeTurns: 2,  /* HR policy + benefits lookup via SharePoint / SNOW KB */
+    toolTurns: 3,       /* Workday employee data + HRSD case read/create */
+    promptTurns: 1,     /* AI summary of case status or policy answer */
+    classicTurns: 1,    /* Greeting / welcome topic */
+    flowTurns: 2,       /* HRSD Create Case + Get Cases List via shared orchestrator */
+    scenarios: 10,
+    iterations: 4,
+    prepaid: 25000,
+    pricingModel: 'prepaid',
+    m365pct: 70,        /* HR tool — broad employee audience, high M365 licence share */
+    examples: {
+      knowledge: {
+        sharepoint: [
+          'What is our parental leave policy for permanent employees?',
+          'When does the benefits open enrollment window close this year?',
+          'Where can I find the performance review guidelines for managers?'
+        ],
+        connectors: [
+          'Search the ServiceNow HR knowledge base for our relocation allowance policy.',
+          'Find HR knowledge articles about visa sponsorship support.'
+        ]
+      },
+      tool: [
+        'Create an HR case for a payslip discrepancy in my March pay.',
+        'Show me the details of my most recent HR case.',
+        'List all my open HR cases and their current status.',
+        'What updates have been added to my open parental leave HR case?'
+      ],
+      prompt: [
+        'Summarise the resolution notes from my last HR case in plain language.'
+      ],
+      classic: [
+        'I need help with an HR request.',
+        'What HR tasks can this agent help me with?',
+        'Thank you, that resolved my query.'
+      ],
+      flow: [
+        'Submit a new HR case for a benefits enrolment correction.',
+        'Retrieve the full list of my HR cases from ServiceNow.'
+      ]
+    }
+  },
+  ess_it: {
+    label: 'Employee Self-Service — IT agent starter (ServiceNow ITSM + Self-Help)',
+    agentType: 'custom',
+    /* Knowledge: SharePoint IT docs + ServiceNow Knowledge KB (M365 Copilot Connector)
+       + Microsoft Self-Help connector for guided M365 troubleshooting
+       Connector data: ServiceNow ITSM incidents via Power Platform connector */
+    ks: { sharepoint: 2, connectors: 3 },
+    sharepointGraph: true,
+    classicTopics: 2,   /* Conversation Start + Agent Handoff (Now Assist / Live Agent) */
+    tools: 5,           /* ITSM: Create Ticket, Get User Tickets, Get Ticket Details, Update Ticket, Get Ticket Updates */
+    prompts: 1,
+    promptTier: 'standard',
+    flows: 1,           /* ITSM Common Orchestrator (template config + shared flow pattern) */
+    flowActions: 22,    /* ITSM flows: create + list + details + update + attachment steps */
+    contentPages: 0,
+    reasoning: true,    /* Diagnostic classification before routing/ticket creation */
+    knowledgeTurns: 2,  /* IT runbook + ServiceNow KB article + Self-Help M365 steps */
+    toolTurns: 3,       /* Ticket create/read/update operations */
+    promptTurns: 1,     /* AI-generated ticket description from user problem description */
+    classicTurns: 1,    /* Greeting / welcome topic */
+    flowTurns: 1,       /* ITSM orchestrator: create or update ticket */
+    scenarios: 12,
+    iterations: 5,
+    prepaid: 25000,
+    pricingModel: 'prepaid',
+    m365pct: 50,        /* IT tool — all employees, roughly half M365 licensed */
+    examples: {
+      knowledge: {
+        sharepoint: [
+          'What is the approved process for requesting admin access to a new application?',
+          'Show me the standard steps for setting up a new device from IT.'
+        ],
+        connectors: [
+          'Search the ServiceNow knowledge base for VPN connection troubleshooting steps.',
+          'Find the IT knowledge article for resetting MFA on my account.',
+          'Show me the Microsoft Self-Help guidance for Outlook not syncing on mobile.'
+        ]
+      },
+      tool: [
+        'Create an IT support ticket — my Outlook keeps crashing on startup.',
+        'Show me all my open IT tickets and their current status.',
+        'Get the full details of incident INC0012345.',
+        'Add a comment to my ticket: the issue is still happening after restarting.',
+        'What is the latest update on my most recent IT ticket?'
+      ],
+      prompt: [
+        'Based on the problem I described, draft a clear and concise IT ticket summary for the helpdesk.'
+      ],
+      classic: [
+        'I need IT help.',
+        'Show me the IT tasks this agent can handle.',
+        'Thanks, the issue is resolved.'
+      ],
+      flow: [
+        'Create a new ServiceNow incident and route it to the network support queue.'
+      ]
+    }
   }
 };
 
-/* ─── Foundry Agent billing rates (Azure OpenAI Global Standard PAYG, April 2026) ───
-   Source: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/ */
+/* ─── Foundry Agent billing rates (Azure OpenAI Global Standard PAYG, May 2026) ───
+   Source: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+   GPT-5.4 series prices are for the <272k context tier; >272k context costs more. */
 const FOUNDRY_MODELS = {
-  'gpt4o_mini':      { label: 'GPT-4o mini',           inputPer1M:  0.15, outputPer1M:  0.60 },
-  'gpt4o':           { label: 'GPT-4o (2024-11-20)',   inputPer1M:  2.50, outputPer1M: 10.00 },
-  'gpt41_nano':      { label: 'GPT-4.1-nano',          inputPer1M:  0.10, outputPer1M:  0.40 },
-  'gpt41_mini':      { label: 'GPT-4.1-mini',          inputPer1M:  0.40, outputPer1M:  1.60 },
-  'gpt41':           { label: 'GPT-4.1',               inputPer1M:  2.00, outputPer1M:  8.00 },
-  'gpt5_nano':       { label: 'GPT-5-nano',            inputPer1M:  0.05, outputPer1M:  0.40 },
-  'gpt5_mini':       { label: 'GPT-5-mini',            inputPer1M:  0.25, outputPer1M:  2.00 },
-  'gpt5':            { label: 'GPT-5 (2025-08-07)',    inputPer1M:  1.25, outputPer1M: 10.00 },
-  'gpt5_1_codex_mini': { label: 'GPT-5.1-codex-mini', inputPer1M:  0.25, outputPer1M:  2.00 },
-  'gpt5_1':          { label: 'GPT-5.1',               inputPer1M:  1.25, outputPer1M: 10.00 },
-  'gpt5_2':          { label: 'GPT-5.2',               inputPer1M:  1.75, outputPer1M: 14.00 },
-  'gpt5_3':          { label: 'GPT-5.3',               inputPer1M:  1.75, outputPer1M: 14.00 },
-  'o4_mini':         { label: 'o4-mini',               inputPer1M:  1.10, outputPer1M:  4.40 },
-  'o3':              { label: 'o3',                    inputPer1M:  2.00, outputPer1M:  8.00 },
+  'gpt4o_mini':      { label: 'GPT-4o mini',                   inputPer1M:  0.15, outputPer1M:   0.60 },
+  'gpt4o':           { label: 'GPT-4o (2024-11-20)',           inputPer1M:  2.50, outputPer1M:  10.00 },
+  'gpt41_nano':      { label: 'GPT-4.1-nano',                  inputPer1M:  0.10, outputPer1M:   0.40 },
+  'gpt41_mini':      { label: 'GPT-4.1-mini',                  inputPer1M:  0.40, outputPer1M:   1.60 },
+  'gpt41':           { label: 'GPT-4.1',                       inputPer1M:  2.00, outputPer1M:   8.00 },
+  'gpt5_nano':       { label: 'GPT-5-nano',                    inputPer1M:  0.05, outputPer1M:   0.40 },
+  'gpt5_mini':       { label: 'GPT-5-mini',                    inputPer1M:  0.25, outputPer1M:   2.00 },
+  'gpt5':            { label: 'GPT-5 (2025-08-07)',            inputPer1M:  1.25, outputPer1M:  10.00 },
+  'gpt5_1_codex_mini': { label: 'GPT-5.1-codex-mini',          inputPer1M:  0.25, outputPer1M:   2.00 },
+  'gpt5_1':          { label: 'GPT-5.1',                       inputPer1M:  1.25, outputPer1M:  10.00 },
+  'gpt5_2':          { label: 'GPT-5.2',                       inputPer1M:  1.75, outputPer1M:  14.00 },
+  'gpt5_3':          { label: 'GPT-5.3',                       inputPer1M:  1.75, outputPer1M:  14.00 },
+  'gpt5_4_nano':     { label: 'GPT-5.4-nano',                  inputPer1M:  0.20, outputPer1M:   1.25 },
+  'gpt5_4_mini':     { label: 'GPT-5.4-mini',                  inputPer1M:  0.75, outputPer1M:   4.50 },
+  'gpt5_4':          { label: 'GPT-5.4 (<272k ctx)',           inputPer1M:  2.50, outputPer1M:  15.00 },
+  'gpt5_4_pro':      { label: 'GPT-5.4 Pro (<272k ctx)',       inputPer1M: 30.00, outputPer1M: 180.00 },
+  'o4_mini':         { label: 'o4-mini',                       inputPer1M:  1.10, outputPer1M:   4.40 },
+  'o3':              { label: 'o3',                            inputPer1M:  2.00, outputPer1M:   8.00 },
 };
 
 const FOUNDRY_TEMPLATES = {
@@ -1657,7 +1828,8 @@ function toggleKS(checkbox, inputId) {
   recalculate();
 }
 function getCreditToUSD() {
-  return el('scale_pricingModel').value === 'prepaid' ? CREDIT_TO_USD_PREPAID : CREDIT_TO_USD_PAYG;
+  const m = el('scale_pricingModel').value;
+  return PRICING_MODEL_RATES[m] != null ? PRICING_MODEL_RATES[m] : CREDIT_TO_USD_PAYG;
 }
 function escapeHtml(str) { const d = document.createElement('div'); d.textContent = str; return d.innerHTML; }
 
@@ -1729,9 +1901,13 @@ function onAgentTypeChange() {
   } else if (at === 'foundry') {
     noteEl.style.display = 'block';
     noteEl.innerHTML = '&#9432; <strong>Microsoft Foundry Agent Service</strong> &mdash; billed by tokens (input + output) to your Azure subscription. No Copilot Studio credits apply. '
-      + 'Models: GPT-4o, GPT-4.1, GPT-5, GPT-5-nano, GPT-5.1, GPT-5.2, GPT-5.3, o3, o4-mini, and more. '
+      + 'Models: GPT-4o, GPT-4.1, GPT-5, GPT-5-nano, GPT-5.1, GPT-5.2, GPT-5.3, GPT-5.4, GPT-5.4 Pro, o3, o4-mini, and more. '
       + '<a href="https://learn.microsoft.com/en-us/azure/foundry/agents/overview" target="_blank" rel="noopener noreferrer" style="color:var(--accent-light);">Foundry Agent Service overview</a> | '
       + '<a href="https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/" target="_blank" rel="noopener noreferrer" style="color:var(--accent-light);">Azure OpenAI pricing</a>';
+  } else if (at === 'custom') {
+    noteEl.style.display = 'block';
+    noteEl.innerHTML = '&#9432; <strong>Voice agents</strong> (NEW in May 2026 Copilot Studio Licensing Guide) are billed by <strong>total call length to the nearest second</strong> plus the configured voice orchestration &mdash; not modeled in this tool. For text-only Copilot Studio agents, continue below. '
+      + '<a href="https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/bizapps/Microsoft-Copilot-Studio-Licensing-Guide-May-2026-PUB.pdf" target="_blank" rel="noopener noreferrer" style="color:var(--accent-light);">Licensing Guide (May 2026)</a>';
   } else {
     noteEl.style.display = 'none';
   }

--- a/traffic-data/2026-05-07.json
+++ b/traffic-data/2026-05-07.json
@@ -1,0 +1,497 @@
+{
+  "collected_at": "2026-05-07",
+  "views": {
+    "count": 1533,
+    "uniques": 429,
+    "views": [
+      {
+        "timestamp": "2026-04-23T00:00:00Z",
+        "count": 138,
+        "uniques": 56
+      },
+      {
+        "timestamp": "2026-04-24T00:00:00Z",
+        "count": 193,
+        "uniques": 58
+      },
+      {
+        "timestamp": "2026-04-25T00:00:00Z",
+        "count": 26,
+        "uniques": 11
+      },
+      {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "count": 15,
+        "uniques": 9
+      },
+      {
+        "timestamp": "2026-04-27T00:00:00Z",
+        "count": 87,
+        "uniques": 47
+      },
+      {
+        "timestamp": "2026-04-28T00:00:00Z",
+        "count": 154,
+        "uniques": 68
+      },
+      {
+        "timestamp": "2026-04-29T00:00:00Z",
+        "count": 211,
+        "uniques": 55
+      },
+      {
+        "timestamp": "2026-04-30T00:00:00Z",
+        "count": 152,
+        "uniques": 53
+      },
+      {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "count": 164,
+        "uniques": 40
+      },
+      {
+        "timestamp": "2026-05-02T00:00:00Z",
+        "count": 23,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-05-03T00:00:00Z",
+        "count": 43,
+        "uniques": 14
+      },
+      {
+        "timestamp": "2026-05-04T00:00:00Z",
+        "count": 124,
+        "uniques": 49
+      },
+      {
+        "timestamp": "2026-05-05T00:00:00Z",
+        "count": 106,
+        "uniques": 43
+      },
+      {
+        "timestamp": "2026-05-06T00:00:00Z",
+        "count": 97,
+        "uniques": 39
+      }
+    ]
+  },
+  "clones": {
+    "count": 670,
+    "uniques": 220,
+    "clones": [
+      {
+        "timestamp": "2026-04-23T00:00:00Z",
+        "count": 54,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-04-24T00:00:00Z",
+        "count": 39,
+        "uniques": 20
+      },
+      {
+        "timestamp": "2026-04-25T00:00:00Z",
+        "count": 37,
+        "uniques": 25
+      },
+      {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "count": 23,
+        "uniques": 12
+      },
+      {
+        "timestamp": "2026-04-27T00:00:00Z",
+        "count": 57,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-04-28T00:00:00Z",
+        "count": 29,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-04-29T00:00:00Z",
+        "count": 29,
+        "uniques": 15
+      },
+      {
+        "timestamp": "2026-04-30T00:00:00Z",
+        "count": 34,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "count": 108,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-05-02T00:00:00Z",
+        "count": 57,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-05-03T00:00:00Z",
+        "count": 23,
+        "uniques": 13
+      },
+      {
+        "timestamp": "2026-05-04T00:00:00Z",
+        "count": 30,
+        "uniques": 12
+      },
+      {
+        "timestamp": "2026-05-05T00:00:00Z",
+        "count": 56,
+        "uniques": 23
+      },
+      {
+        "timestamp": "2026-05-06T00:00:00Z",
+        "count": 94,
+        "uniques": 34
+      }
+    ]
+  },
+  "referrers": [
+    {
+      "referrer": "Bing",
+      "count": 246,
+      "uniques": 56
+    },
+    {
+      "referrer": "statics.teams.cdn.office.net",
+      "count": 125,
+      "uniques": 54
+    },
+    {
+      "referrer": "github.com",
+      "count": 116,
+      "uniques": 40
+    },
+    {
+      "referrer": "teams.public.onecdn.static.microsoft",
+      "count": 47,
+      "uniques": 16
+    },
+    {
+      "referrer": "learn.microsoft.com",
+      "count": 43,
+      "uniques": 20
+    },
+    {
+      "referrer": "Google",
+      "count": 30,
+      "uniques": 18
+    },
+    {
+      "referrer": "engage.cloud.microsoft",
+      "count": 24,
+      "uniques": 4
+    },
+    {
+      "referrer": "linkedin.com",
+      "count": 9,
+      "uniques": 5
+    },
+    {
+      "referrer": "teams.df.onecdn.static.microsoft",
+      "count": 8,
+      "uniques": 2
+    },
+    {
+      "referrer": "community.spiceworks.com",
+      "count": 5,
+      "uniques": 2
+    }
+  ],
+  "paths": [
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+      "title": "/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+      "count": 122,
+      "uniques": 70
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+      "title": "/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+      "count": 97,
+      "uniques": 57
+    },
+    {
+      "path": "/microsoft/FastTrack",
+      "title": "Overview",
+      "count": 88,
+      "uniques": 57
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples",
+      "title": "/tree/master/copilot-analytics-samples",
+      "count": 79,
+      "uniques": 50
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents",
+      "title": "/tree/master/copilot-agent-samples/copilot-studio-agents",
+      "count": 63,
+      "uniques": 47
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+      "title": "/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+      "count": 59,
+      "uniques": 34
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples",
+      "title": "/tree/master/copilot-agent-samples",
+      "count": 47,
+      "uniques": 31
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+      "title": "/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+      "count": 41,
+      "uniques": 29
+    },
+    {
+      "path": "/microsoft/FastTrack/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+      "title": "/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+      "count": 40,
+      "uniques": 26
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/scripts/Update-VivaEngageLicensingToggle",
+      "title": "/tree/master/scripts/Update-VivaEngageLicensingToggle",
+      "count": 34,
+      "uniques": 23
+    }
+  ],
+  "stars": 211,
+  "forks": 124,
+  "star_timeline": [
+    "2018-03-05T17:58:58Z",
+    "2018-04-04T15:53:39Z",
+    "2018-06-27T16:48:11Z",
+    "2018-07-24T20:01:01Z",
+    "2018-07-25T05:57:33Z",
+    "2018-07-31T04:15:49Z",
+    "2018-07-31T18:03:48Z",
+    "2018-08-01T10:22:09Z",
+    "2018-08-07T08:37:51Z",
+    "2018-08-17T19:49:47Z",
+    "2018-09-04T19:46:20Z",
+    "2018-10-04T14:30:06Z",
+    "2018-10-10T23:07:41Z",
+    "2018-10-29T19:26:23Z",
+    "2018-10-31T18:23:59Z",
+    "2018-11-30T09:17:38Z",
+    "2019-01-15T19:36:39Z",
+    "2019-01-16T11:21:15Z",
+    "2019-01-22T09:32:53Z",
+    "2019-01-24T08:53:20Z",
+    "2019-01-25T06:23:38Z",
+    "2019-02-01T20:52:10Z",
+    "2019-02-04T15:59:03Z",
+    "2019-02-05T17:00:23Z",
+    "2019-03-08T00:37:59Z",
+    "2019-03-30T14:22:47Z",
+    "2019-05-08T11:32:25Z",
+    "2019-05-10T18:35:57Z",
+    "2019-07-22T15:25:51Z",
+    "2019-08-05T15:01:02Z",
+    "2019-08-19T20:18:36Z",
+    "2019-08-21T13:21:45Z",
+    "2019-09-08T04:26:12Z",
+    "2019-09-18T14:54:07Z",
+    "2019-11-19T03:12:32Z",
+    "2019-12-09T12:22:43Z",
+    "2019-12-11T12:58:56Z",
+    "2019-12-22T14:37:50Z",
+    "2019-12-28T17:16:13Z",
+    "2020-01-09T16:29:43Z",
+    "2020-01-10T08:40:28Z",
+    "2020-01-15T22:51:03Z",
+    "2020-01-17T16:55:18Z",
+    "2020-01-22T14:40:52Z",
+    "2020-02-25T02:54:44Z",
+    "2020-03-03T10:54:03Z",
+    "2020-03-06T09:14:22Z",
+    "2020-03-17T23:38:29Z",
+    "2020-03-26T15:12:52Z",
+    "2020-04-11T10:10:33Z",
+    "2020-04-29T11:56:14Z",
+    "2020-05-09T09:36:02Z",
+    "2020-05-29T17:16:59Z",
+    "2020-07-20T16:45:09Z",
+    "2020-08-04T18:24:54Z",
+    "2020-08-10T18:32:13Z",
+    "2020-08-12T11:47:19Z",
+    "2020-08-12T13:19:42Z",
+    "2020-08-24T09:22:57Z",
+    "2020-08-31T00:30:11Z",
+    "2020-09-15T22:36:51Z",
+    "2020-10-15T10:27:16Z",
+    "2020-11-11T13:50:07Z",
+    "2020-12-07T10:40:40Z",
+    "2020-12-10T01:50:23Z",
+    "2021-01-11T10:52:43Z",
+    "2021-01-13T13:14:59Z",
+    "2021-01-18T09:24:29Z",
+    "2021-02-02T21:42:37Z",
+    "2021-02-12T17:52:34Z",
+    "2021-02-22T16:52:41Z",
+    "2021-03-03T00:05:25Z",
+    "2021-03-08T15:57:35Z",
+    "2021-03-17T17:00:12Z",
+    "2021-03-25T09:25:17Z",
+    "2021-04-14T08:51:06Z",
+    "2021-04-15T07:26:55Z",
+    "2021-04-20T16:13:52Z",
+    "2021-04-26T14:07:56Z",
+    "2021-04-30T18:08:14Z",
+    "2021-05-28T10:46:11Z",
+    "2021-06-01T20:52:00Z",
+    "2021-06-14T07:26:29Z",
+    "2021-06-15T19:24:23Z",
+    "2021-06-24T15:40:55Z",
+    "2021-07-29T14:49:44Z",
+    "2021-08-04T18:10:17Z",
+    "2021-08-13T15:05:39Z",
+    "2021-08-16T23:19:02Z",
+    "2021-09-07T14:37:42Z",
+    "2021-09-16T09:56:17Z",
+    "2021-09-21T16:26:30Z",
+    "2021-10-01T10:11:50Z",
+    "2021-10-19T17:52:14Z",
+    "2021-10-24T01:23:36Z",
+    "2021-11-08T21:13:53Z",
+    "2021-11-15T20:56:12Z",
+    "2021-12-20T22:55:19Z",
+    "2022-01-13T17:34:27Z",
+    "2022-02-11T12:43:21Z",
+    "2022-03-19T16:22:15Z",
+    "2022-03-25T01:55:40Z",
+    "2022-04-17T23:57:53Z",
+    "2022-04-29T15:09:50Z",
+    "2022-05-16T07:35:16Z",
+    "2022-05-20T15:20:18Z",
+    "2022-05-22T13:23:34Z",
+    "2022-07-02T18:52:24Z",
+    "2022-07-31T01:09:26Z",
+    "2022-08-31T18:12:17Z",
+    "2022-09-27T04:38:05Z",
+    "2022-09-28T16:57:39Z",
+    "2022-09-30T13:38:09Z",
+    "2022-10-06T20:44:17Z",
+    "2022-10-10T22:41:12Z",
+    "2022-10-12T16:54:21Z",
+    "2022-11-27T14:50:12Z",
+    "2022-12-02T18:02:55Z",
+    "2022-12-20T19:38:18Z",
+    "2022-12-27T04:02:13Z",
+    "2023-01-13T00:26:03Z",
+    "2023-01-13T22:33:46Z",
+    "2023-01-14T08:05:33Z",
+    "2023-01-18T22:07:33Z",
+    "2023-02-10T13:56:11Z",
+    "2023-02-14T21:13:55Z",
+    "2023-02-16T16:55:43Z",
+    "2023-02-19T10:16:18Z",
+    "2023-03-13T18:14:30Z",
+    "2023-04-07T21:43:41Z",
+    "2023-04-15T04:07:31Z",
+    "2023-05-01T16:58:37Z",
+    "2023-05-12T21:55:47Z",
+    "2023-05-13T14:31:35Z",
+    "2023-05-21T18:30:09Z",
+    "2023-06-17T14:32:44Z",
+    "2023-06-18T13:12:07Z",
+    "2023-07-06T16:00:32Z",
+    "2023-08-29T14:03:48Z",
+    "2023-11-02T02:15:25Z",
+    "2023-11-08T16:58:07Z",
+    "2023-11-14T10:19:47Z",
+    "2023-11-15T15:53:18Z",
+    "2023-12-19T11:18:55Z",
+    "2024-04-17T18:30:49Z",
+    "2024-05-07T03:09:57Z",
+    "2024-05-13T17:43:38Z",
+    "2024-05-15T00:54:50Z",
+    "2024-05-20T17:21:55Z",
+    "2024-05-31T11:05:14Z",
+    "2024-06-20T22:51:20Z",
+    "2024-07-12T17:45:26Z",
+    "2024-08-13T16:00:16Z",
+    "2024-08-21T05:50:26Z",
+    "2024-08-21T18:01:04Z",
+    "2024-09-11T04:51:24Z",
+    "2024-10-20T19:07:10Z",
+    "2024-12-22T08:46:15Z",
+    "2025-02-25T19:07:03Z",
+    "2025-03-20T21:45:01Z",
+    "2025-04-04T01:57:54Z",
+    "2025-04-04T12:35:23Z",
+    "2025-04-30T04:58:47Z",
+    "2025-05-02T18:33:21Z",
+    "2025-05-31T19:40:53Z",
+    "2025-07-17T11:02:46Z",
+    "2025-08-22T21:01:22Z",
+    "2025-08-23T06:19:26Z",
+    "2025-09-06T06:49:28Z",
+    "2025-09-22T22:10:42Z",
+    "2025-09-23T23:02:04Z",
+    "2025-09-24T18:54:24Z",
+    "2025-10-10T01:46:48Z",
+    "2025-10-29T09:15:20Z",
+    "2025-11-10T14:34:27Z",
+    "2025-11-13T20:39:03Z",
+    "2025-11-15T18:48:14Z",
+    "2025-11-25T19:29:26Z",
+    "2025-12-03T14:04:37Z",
+    "2025-12-22T12:25:21Z",
+    "2026-01-09T13:23:03Z",
+    "2026-01-14T21:23:05Z",
+    "2026-01-16T23:16:48Z",
+    "2026-01-26T13:02:52Z",
+    "2026-01-27T17:33:33Z",
+    "2026-01-31T07:34:06Z",
+    "2026-02-03T23:41:12Z",
+    "2026-02-10T20:46:20Z",
+    "2026-03-06T02:39:04Z",
+    "2026-03-06T21:46:08Z",
+    "2026-03-09T03:15:15Z",
+    "2026-03-09T14:40:11Z",
+    "2026-03-11T05:57:59Z",
+    "2026-03-21T08:43:29Z",
+    "2026-03-26T16:11:36Z",
+    "2026-03-31T16:12:39Z",
+    "2026-04-03T00:29:32Z",
+    "2026-04-03T12:15:11Z",
+    "2026-04-03T15:19:07Z",
+    "2026-04-05T19:40:55Z",
+    "2026-04-07T15:53:29Z",
+    "2026-04-09T16:16:25Z",
+    "2026-04-12T17:09:43Z",
+    "2026-04-18T10:06:20Z",
+    "2026-04-19T03:07:55Z",
+    "2026-04-21T04:15:23Z",
+    "2026-04-23T03:20:28Z",
+    "2026-04-26T06:34:30Z",
+    "2026-04-28T15:43:30Z",
+    "2026-05-03T05:49:05Z",
+    "2026-05-06T19:58:40Z"
+  ],
+  "stargazer_locations": [
+    "Costa Rica",
+    "Seattle",
+    "Sydney, Australia",
+    "Hilbert Space",
+    "Texas",
+    "Seattle WA",
+    "Chicago",
+    "Toronto, Ontario, Canada",
+    "MTL",
+    "Fortaleza",
+    "London"
+  ]
+}

--- a/traffic-data/2026-05-08.json
+++ b/traffic-data/2026-05-08.json
@@ -1,0 +1,499 @@
+{
+  "collected_at": "2026-05-08",
+  "views": {
+    "count": 1533,
+    "uniques": 429,
+    "views": [
+      {
+        "timestamp": "2026-04-23T00:00:00Z",
+        "count": 138,
+        "uniques": 56
+      },
+      {
+        "timestamp": "2026-04-24T00:00:00Z",
+        "count": 193,
+        "uniques": 58
+      },
+      {
+        "timestamp": "2026-04-25T00:00:00Z",
+        "count": 26,
+        "uniques": 11
+      },
+      {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "count": 15,
+        "uniques": 9
+      },
+      {
+        "timestamp": "2026-04-27T00:00:00Z",
+        "count": 87,
+        "uniques": 47
+      },
+      {
+        "timestamp": "2026-04-28T00:00:00Z",
+        "count": 154,
+        "uniques": 68
+      },
+      {
+        "timestamp": "2026-04-29T00:00:00Z",
+        "count": 211,
+        "uniques": 55
+      },
+      {
+        "timestamp": "2026-04-30T00:00:00Z",
+        "count": 152,
+        "uniques": 53
+      },
+      {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "count": 164,
+        "uniques": 40
+      },
+      {
+        "timestamp": "2026-05-02T00:00:00Z",
+        "count": 23,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-05-03T00:00:00Z",
+        "count": 43,
+        "uniques": 14
+      },
+      {
+        "timestamp": "2026-05-04T00:00:00Z",
+        "count": 124,
+        "uniques": 49
+      },
+      {
+        "timestamp": "2026-05-05T00:00:00Z",
+        "count": 106,
+        "uniques": 43
+      },
+      {
+        "timestamp": "2026-05-06T00:00:00Z",
+        "count": 97,
+        "uniques": 39
+      }
+    ]
+  },
+  "clones": {
+    "count": 670,
+    "uniques": 220,
+    "clones": [
+      {
+        "timestamp": "2026-04-23T00:00:00Z",
+        "count": 54,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-04-24T00:00:00Z",
+        "count": 39,
+        "uniques": 20
+      },
+      {
+        "timestamp": "2026-04-25T00:00:00Z",
+        "count": 37,
+        "uniques": 25
+      },
+      {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "count": 23,
+        "uniques": 12
+      },
+      {
+        "timestamp": "2026-04-27T00:00:00Z",
+        "count": 57,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-04-28T00:00:00Z",
+        "count": 29,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-04-29T00:00:00Z",
+        "count": 29,
+        "uniques": 15
+      },
+      {
+        "timestamp": "2026-04-30T00:00:00Z",
+        "count": 34,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "count": 108,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-05-02T00:00:00Z",
+        "count": 57,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-05-03T00:00:00Z",
+        "count": 23,
+        "uniques": 13
+      },
+      {
+        "timestamp": "2026-05-04T00:00:00Z",
+        "count": 30,
+        "uniques": 12
+      },
+      {
+        "timestamp": "2026-05-05T00:00:00Z",
+        "count": 56,
+        "uniques": 23
+      },
+      {
+        "timestamp": "2026-05-06T00:00:00Z",
+        "count": 94,
+        "uniques": 34
+      }
+    ]
+  },
+  "referrers": [
+    {
+      "referrer": "Bing",
+      "count": 246,
+      "uniques": 56
+    },
+    {
+      "referrer": "statics.teams.cdn.office.net",
+      "count": 125,
+      "uniques": 54
+    },
+    {
+      "referrer": "github.com",
+      "count": 116,
+      "uniques": 40
+    },
+    {
+      "referrer": "teams.public.onecdn.static.microsoft",
+      "count": 47,
+      "uniques": 16
+    },
+    {
+      "referrer": "learn.microsoft.com",
+      "count": 43,
+      "uniques": 20
+    },
+    {
+      "referrer": "Google",
+      "count": 30,
+      "uniques": 18
+    },
+    {
+      "referrer": "engage.cloud.microsoft",
+      "count": 24,
+      "uniques": 4
+    },
+    {
+      "referrer": "linkedin.com",
+      "count": 9,
+      "uniques": 5
+    },
+    {
+      "referrer": "teams.df.onecdn.static.microsoft",
+      "count": 8,
+      "uniques": 2
+    },
+    {
+      "referrer": "community.spiceworks.com",
+      "count": 5,
+      "uniques": 2
+    }
+  ],
+  "paths": [
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+      "title": "/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+      "count": 122,
+      "uniques": 70
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+      "title": "/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+      "count": 97,
+      "uniques": 57
+    },
+    {
+      "path": "/microsoft/FastTrack",
+      "title": "Overview",
+      "count": 88,
+      "uniques": 57
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples",
+      "title": "/tree/master/copilot-analytics-samples",
+      "count": 79,
+      "uniques": 50
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents",
+      "title": "/tree/master/copilot-agent-samples/copilot-studio-agents",
+      "count": 63,
+      "uniques": 47
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+      "title": "/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+      "count": 59,
+      "uniques": 34
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples",
+      "title": "/tree/master/copilot-agent-samples",
+      "count": 47,
+      "uniques": 31
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+      "title": "/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+      "count": 41,
+      "uniques": 29
+    },
+    {
+      "path": "/microsoft/FastTrack/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+      "title": "/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+      "count": 40,
+      "uniques": 26
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/scripts/Update-VivaEngageLicensingToggle",
+      "title": "/tree/master/scripts/Update-VivaEngageLicensingToggle",
+      "count": 34,
+      "uniques": 23
+    }
+  ],
+  "stars": 212,
+  "forks": 124,
+  "star_timeline": [
+    "2018-03-05T17:58:58Z",
+    "2018-04-04T15:53:39Z",
+    "2018-06-27T16:48:11Z",
+    "2018-07-24T20:01:01Z",
+    "2018-07-25T05:57:33Z",
+    "2018-07-31T04:15:49Z",
+    "2018-07-31T18:03:48Z",
+    "2018-08-01T10:22:09Z",
+    "2018-08-07T08:37:51Z",
+    "2018-08-17T19:49:47Z",
+    "2018-09-04T19:46:20Z",
+    "2018-10-04T14:30:06Z",
+    "2018-10-10T23:07:41Z",
+    "2018-10-29T19:26:23Z",
+    "2018-10-31T18:23:59Z",
+    "2018-11-30T09:17:38Z",
+    "2019-01-15T19:36:39Z",
+    "2019-01-16T11:21:15Z",
+    "2019-01-22T09:32:53Z",
+    "2019-01-24T08:53:20Z",
+    "2019-01-25T06:23:38Z",
+    "2019-02-01T20:52:10Z",
+    "2019-02-04T15:59:03Z",
+    "2019-02-05T17:00:23Z",
+    "2019-03-08T00:37:59Z",
+    "2019-03-30T14:22:47Z",
+    "2019-05-08T11:32:25Z",
+    "2019-05-10T18:35:57Z",
+    "2019-07-22T15:25:51Z",
+    "2019-08-05T15:01:02Z",
+    "2019-08-19T20:18:36Z",
+    "2019-08-21T13:21:45Z",
+    "2019-09-08T04:26:12Z",
+    "2019-09-18T14:54:07Z",
+    "2019-11-19T03:12:32Z",
+    "2019-12-09T12:22:43Z",
+    "2019-12-11T12:58:56Z",
+    "2019-12-22T14:37:50Z",
+    "2019-12-28T17:16:13Z",
+    "2020-01-09T16:29:43Z",
+    "2020-01-10T08:40:28Z",
+    "2020-01-15T22:51:03Z",
+    "2020-01-17T16:55:18Z",
+    "2020-01-22T14:40:52Z",
+    "2020-02-25T02:54:44Z",
+    "2020-03-03T10:54:03Z",
+    "2020-03-06T09:14:22Z",
+    "2020-03-17T23:38:29Z",
+    "2020-03-26T15:12:52Z",
+    "2020-04-11T10:10:33Z",
+    "2020-04-29T11:56:14Z",
+    "2020-05-09T09:36:02Z",
+    "2020-05-29T17:16:59Z",
+    "2020-07-20T16:45:09Z",
+    "2020-08-04T18:24:54Z",
+    "2020-08-10T18:32:13Z",
+    "2020-08-12T11:47:19Z",
+    "2020-08-12T13:19:42Z",
+    "2020-08-24T09:22:57Z",
+    "2020-08-31T00:30:11Z",
+    "2020-09-15T22:36:51Z",
+    "2020-10-15T10:27:16Z",
+    "2020-11-11T13:50:07Z",
+    "2020-12-07T10:40:40Z",
+    "2020-12-10T01:50:23Z",
+    "2021-01-11T10:52:43Z",
+    "2021-01-13T13:14:59Z",
+    "2021-01-18T09:24:29Z",
+    "2021-02-02T21:42:37Z",
+    "2021-02-12T17:52:34Z",
+    "2021-02-22T16:52:41Z",
+    "2021-03-03T00:05:25Z",
+    "2021-03-08T15:57:35Z",
+    "2021-03-17T17:00:12Z",
+    "2021-03-25T09:25:17Z",
+    "2021-04-14T08:51:06Z",
+    "2021-04-15T07:26:55Z",
+    "2021-04-20T16:13:52Z",
+    "2021-04-26T14:07:56Z",
+    "2021-04-30T18:08:14Z",
+    "2021-05-28T10:46:11Z",
+    "2021-06-01T20:52:00Z",
+    "2021-06-14T07:26:29Z",
+    "2021-06-15T19:24:23Z",
+    "2021-06-24T15:40:55Z",
+    "2021-07-29T14:49:44Z",
+    "2021-08-04T18:10:17Z",
+    "2021-08-13T15:05:39Z",
+    "2021-08-16T23:19:02Z",
+    "2021-09-07T14:37:42Z",
+    "2021-09-16T09:56:17Z",
+    "2021-09-21T16:26:30Z",
+    "2021-10-01T10:11:50Z",
+    "2021-10-19T17:52:14Z",
+    "2021-10-24T01:23:36Z",
+    "2021-11-08T21:13:53Z",
+    "2021-11-15T20:56:12Z",
+    "2021-12-20T22:55:19Z",
+    "2022-01-13T17:34:27Z",
+    "2022-02-11T12:43:21Z",
+    "2022-03-19T16:22:15Z",
+    "2022-03-25T01:55:40Z",
+    "2022-04-17T23:57:53Z",
+    "2022-04-29T15:09:50Z",
+    "2022-05-16T07:35:16Z",
+    "2022-05-20T15:20:18Z",
+    "2022-05-22T13:23:34Z",
+    "2022-07-02T18:52:24Z",
+    "2022-07-31T01:09:26Z",
+    "2022-08-31T18:12:17Z",
+    "2022-09-27T04:38:05Z",
+    "2022-09-28T16:57:39Z",
+    "2022-09-30T13:38:09Z",
+    "2022-10-06T20:44:17Z",
+    "2022-10-10T22:41:12Z",
+    "2022-10-12T16:54:21Z",
+    "2022-11-27T14:50:12Z",
+    "2022-12-02T18:02:55Z",
+    "2022-12-20T19:38:18Z",
+    "2022-12-27T04:02:13Z",
+    "2023-01-13T00:26:03Z",
+    "2023-01-13T22:33:46Z",
+    "2023-01-14T08:05:33Z",
+    "2023-01-18T22:07:33Z",
+    "2023-02-10T13:56:11Z",
+    "2023-02-14T21:13:55Z",
+    "2023-02-16T16:55:43Z",
+    "2023-02-19T10:16:18Z",
+    "2023-03-13T18:14:30Z",
+    "2023-04-07T21:43:41Z",
+    "2023-04-15T04:07:31Z",
+    "2023-05-01T16:58:37Z",
+    "2023-05-12T21:55:47Z",
+    "2023-05-13T14:31:35Z",
+    "2023-05-21T18:30:09Z",
+    "2023-06-17T14:32:44Z",
+    "2023-06-18T13:12:07Z",
+    "2023-07-06T16:00:32Z",
+    "2023-08-29T14:03:48Z",
+    "2023-11-02T02:15:25Z",
+    "2023-11-08T16:58:07Z",
+    "2023-11-14T10:19:47Z",
+    "2023-11-15T15:53:18Z",
+    "2023-12-19T11:18:55Z",
+    "2024-04-17T18:30:49Z",
+    "2024-05-07T03:09:57Z",
+    "2024-05-13T17:43:38Z",
+    "2024-05-15T00:54:50Z",
+    "2024-05-20T17:21:55Z",
+    "2024-05-31T11:05:14Z",
+    "2024-06-20T22:51:20Z",
+    "2024-07-12T17:45:26Z",
+    "2024-08-13T16:00:16Z",
+    "2024-08-21T05:50:26Z",
+    "2024-08-21T18:01:04Z",
+    "2024-09-11T04:51:24Z",
+    "2024-10-20T19:07:10Z",
+    "2024-12-22T08:46:15Z",
+    "2025-02-25T19:07:03Z",
+    "2025-03-20T21:45:01Z",
+    "2025-04-04T01:57:54Z",
+    "2025-04-04T12:35:23Z",
+    "2025-04-30T04:58:47Z",
+    "2025-05-02T18:33:21Z",
+    "2025-05-31T19:40:53Z",
+    "2025-07-17T11:02:46Z",
+    "2025-08-22T21:01:22Z",
+    "2025-08-23T06:19:26Z",
+    "2025-09-06T06:49:28Z",
+    "2025-09-22T22:10:42Z",
+    "2025-09-23T23:02:04Z",
+    "2025-09-24T18:54:24Z",
+    "2025-10-10T01:46:48Z",
+    "2025-10-29T09:15:20Z",
+    "2025-11-10T14:34:27Z",
+    "2025-11-13T20:39:03Z",
+    "2025-11-15T18:48:14Z",
+    "2025-11-25T19:29:26Z",
+    "2025-12-03T14:04:37Z",
+    "2025-12-22T12:25:21Z",
+    "2026-01-09T13:23:03Z",
+    "2026-01-14T21:23:05Z",
+    "2026-01-16T23:16:48Z",
+    "2026-01-26T13:02:52Z",
+    "2026-01-27T17:33:33Z",
+    "2026-01-31T07:34:06Z",
+    "2026-02-03T23:41:12Z",
+    "2026-02-10T20:46:20Z",
+    "2026-03-06T02:39:04Z",
+    "2026-03-06T21:46:08Z",
+    "2026-03-09T03:15:15Z",
+    "2026-03-09T14:40:11Z",
+    "2026-03-11T05:57:59Z",
+    "2026-03-21T08:43:29Z",
+    "2026-03-26T16:11:36Z",
+    "2026-03-31T16:12:39Z",
+    "2026-04-03T00:29:32Z",
+    "2026-04-03T12:15:11Z",
+    "2026-04-03T15:19:07Z",
+    "2026-04-05T19:40:55Z",
+    "2026-04-07T15:53:29Z",
+    "2026-04-09T16:16:25Z",
+    "2026-04-12T17:09:43Z",
+    "2026-04-18T10:06:20Z",
+    "2026-04-19T03:07:55Z",
+    "2026-04-21T04:15:23Z",
+    "2026-04-23T03:20:28Z",
+    "2026-04-26T06:34:30Z",
+    "2026-04-28T15:43:30Z",
+    "2026-05-03T05:49:05Z",
+    "2026-05-06T19:58:40Z",
+    "2026-05-07T15:01:59Z"
+  ],
+  "stargazer_locations": [
+    "Costa Rica",
+    "Seattle",
+    "Sydney, Australia",
+    "Hilbert Space",
+    "Texas",
+    "Seattle WA",
+    "Chicago",
+    "Toronto, Ontario, Canada",
+    "MTL",
+    "Fortaleza",
+    "London",
+    "Brazil, Minas Gerais, Alfenas"
+  ]
+}

--- a/traffic-data/2026-05-09.json
+++ b/traffic-data/2026-05-09.json
@@ -1,0 +1,499 @@
+{
+  "collected_at": "2026-05-09",
+  "views": {
+    "count": 1522,
+    "uniques": 424,
+    "views": [
+      {
+        "timestamp": "2026-04-24T00:00:00Z",
+        "count": 193,
+        "uniques": 58
+      },
+      {
+        "timestamp": "2026-04-25T00:00:00Z",
+        "count": 26,
+        "uniques": 11
+      },
+      {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "count": 15,
+        "uniques": 9
+      },
+      {
+        "timestamp": "2026-04-27T00:00:00Z",
+        "count": 87,
+        "uniques": 47
+      },
+      {
+        "timestamp": "2026-04-28T00:00:00Z",
+        "count": 154,
+        "uniques": 68
+      },
+      {
+        "timestamp": "2026-04-29T00:00:00Z",
+        "count": 211,
+        "uniques": 55
+      },
+      {
+        "timestamp": "2026-04-30T00:00:00Z",
+        "count": 152,
+        "uniques": 53
+      },
+      {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "count": 164,
+        "uniques": 40
+      },
+      {
+        "timestamp": "2026-05-02T00:00:00Z",
+        "count": 23,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-05-03T00:00:00Z",
+        "count": 43,
+        "uniques": 14
+      },
+      {
+        "timestamp": "2026-05-04T00:00:00Z",
+        "count": 124,
+        "uniques": 49
+      },
+      {
+        "timestamp": "2026-05-05T00:00:00Z",
+        "count": 106,
+        "uniques": 43
+      },
+      {
+        "timestamp": "2026-05-06T00:00:00Z",
+        "count": 97,
+        "uniques": 39
+      },
+      {
+        "timestamp": "2026-05-07T00:00:00Z",
+        "count": 127,
+        "uniques": 54
+      }
+    ]
+  },
+  "clones": {
+    "count": 677,
+    "uniques": 219,
+    "clones": [
+      {
+        "timestamp": "2026-04-24T00:00:00Z",
+        "count": 39,
+        "uniques": 20
+      },
+      {
+        "timestamp": "2026-04-25T00:00:00Z",
+        "count": 37,
+        "uniques": 25
+      },
+      {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "count": 23,
+        "uniques": 12
+      },
+      {
+        "timestamp": "2026-04-27T00:00:00Z",
+        "count": 57,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-04-28T00:00:00Z",
+        "count": 29,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-04-29T00:00:00Z",
+        "count": 29,
+        "uniques": 15
+      },
+      {
+        "timestamp": "2026-04-30T00:00:00Z",
+        "count": 34,
+        "uniques": 16
+      },
+      {
+        "timestamp": "2026-05-01T00:00:00Z",
+        "count": 108,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-05-02T00:00:00Z",
+        "count": 57,
+        "uniques": 22
+      },
+      {
+        "timestamp": "2026-05-03T00:00:00Z",
+        "count": 23,
+        "uniques": 13
+      },
+      {
+        "timestamp": "2026-05-04T00:00:00Z",
+        "count": 30,
+        "uniques": 12
+      },
+      {
+        "timestamp": "2026-05-05T00:00:00Z",
+        "count": 56,
+        "uniques": 23
+      },
+      {
+        "timestamp": "2026-05-06T00:00:00Z",
+        "count": 94,
+        "uniques": 34
+      },
+      {
+        "timestamp": "2026-05-07T00:00:00Z",
+        "count": 61,
+        "uniques": 21
+      }
+    ]
+  },
+  "referrers": [
+    {
+      "referrer": "Bing",
+      "count": 205,
+      "uniques": 54
+    },
+    {
+      "referrer": "statics.teams.cdn.office.net",
+      "count": 142,
+      "uniques": 55
+    },
+    {
+      "referrer": "github.com",
+      "count": 129,
+      "uniques": 41
+    },
+    {
+      "referrer": "teams.public.onecdn.static.microsoft",
+      "count": 64,
+      "uniques": 23
+    },
+    {
+      "referrer": "learn.microsoft.com",
+      "count": 41,
+      "uniques": 19
+    },
+    {
+      "referrer": "Google",
+      "count": 30,
+      "uniques": 18
+    },
+    {
+      "referrer": "engage.cloud.microsoft",
+      "count": 22,
+      "uniques": 3
+    },
+    {
+      "referrer": "teams.df.onecdn.static.microsoft",
+      "count": 10,
+      "uniques": 3
+    },
+    {
+      "referrer": "linkedin.com",
+      "count": 8,
+      "uniques": 7
+    },
+    {
+      "referrer": "community.spiceworks.com",
+      "count": 5,
+      "uniques": 2
+    }
+  ],
+  "paths": [
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+      "title": "/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+      "count": 116,
+      "uniques": 68
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+      "title": "/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+      "count": 102,
+      "uniques": 58
+    },
+    {
+      "path": "/microsoft/FastTrack",
+      "title": "Overview",
+      "count": 89,
+      "uniques": 59
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples",
+      "title": "/tree/master/copilot-analytics-samples",
+      "count": 73,
+      "uniques": 44
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents",
+      "title": "/tree/master/copilot-agent-samples/copilot-studio-agents",
+      "count": 63,
+      "uniques": 47
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+      "title": "/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+      "count": 63,
+      "uniques": 35
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples",
+      "title": "/tree/master/copilot-agent-samples",
+      "count": 49,
+      "uniques": 32
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+      "title": "/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+      "count": 43,
+      "uniques": 31
+    },
+    {
+      "path": "/microsoft/FastTrack/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+      "title": "/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+      "count": 40,
+      "uniques": 26
+    },
+    {
+      "path": "/microsoft/FastTrack/tree/master/scripts/Update-VivaEngageLicensingToggle",
+      "title": "/tree/master/scripts/Update-VivaEngageLicensingToggle",
+      "count": 32,
+      "uniques": 22
+    }
+  ],
+  "stars": 212,
+  "forks": 124,
+  "star_timeline": [
+    "2018-03-05T17:58:58Z",
+    "2018-04-04T15:53:39Z",
+    "2018-06-27T16:48:11Z",
+    "2018-07-24T20:01:01Z",
+    "2018-07-25T05:57:33Z",
+    "2018-07-31T04:15:49Z",
+    "2018-07-31T18:03:48Z",
+    "2018-08-01T10:22:09Z",
+    "2018-08-07T08:37:51Z",
+    "2018-08-17T19:49:47Z",
+    "2018-09-04T19:46:20Z",
+    "2018-10-04T14:30:06Z",
+    "2018-10-10T23:07:41Z",
+    "2018-10-29T19:26:23Z",
+    "2018-10-31T18:23:59Z",
+    "2018-11-30T09:17:38Z",
+    "2019-01-15T19:36:39Z",
+    "2019-01-16T11:21:15Z",
+    "2019-01-22T09:32:53Z",
+    "2019-01-24T08:53:20Z",
+    "2019-01-25T06:23:38Z",
+    "2019-02-01T20:52:10Z",
+    "2019-02-04T15:59:03Z",
+    "2019-02-05T17:00:23Z",
+    "2019-03-08T00:37:59Z",
+    "2019-03-30T14:22:47Z",
+    "2019-05-08T11:32:25Z",
+    "2019-05-10T18:35:57Z",
+    "2019-07-22T15:25:51Z",
+    "2019-08-05T15:01:02Z",
+    "2019-08-19T20:18:36Z",
+    "2019-08-21T13:21:45Z",
+    "2019-09-08T04:26:12Z",
+    "2019-09-18T14:54:07Z",
+    "2019-11-19T03:12:32Z",
+    "2019-12-09T12:22:43Z",
+    "2019-12-11T12:58:56Z",
+    "2019-12-22T14:37:50Z",
+    "2019-12-28T17:16:13Z",
+    "2020-01-09T16:29:43Z",
+    "2020-01-10T08:40:28Z",
+    "2020-01-15T22:51:03Z",
+    "2020-01-17T16:55:18Z",
+    "2020-01-22T14:40:52Z",
+    "2020-02-25T02:54:44Z",
+    "2020-03-03T10:54:03Z",
+    "2020-03-06T09:14:22Z",
+    "2020-03-17T23:38:29Z",
+    "2020-03-26T15:12:52Z",
+    "2020-04-11T10:10:33Z",
+    "2020-04-29T11:56:14Z",
+    "2020-05-09T09:36:02Z",
+    "2020-05-29T17:16:59Z",
+    "2020-07-20T16:45:09Z",
+    "2020-08-04T18:24:54Z",
+    "2020-08-10T18:32:13Z",
+    "2020-08-12T11:47:19Z",
+    "2020-08-12T13:19:42Z",
+    "2020-08-24T09:22:57Z",
+    "2020-08-31T00:30:11Z",
+    "2020-09-15T22:36:51Z",
+    "2020-10-15T10:27:16Z",
+    "2020-11-11T13:50:07Z",
+    "2020-12-07T10:40:40Z",
+    "2020-12-10T01:50:23Z",
+    "2021-01-11T10:52:43Z",
+    "2021-01-13T13:14:59Z",
+    "2021-01-18T09:24:29Z",
+    "2021-02-02T21:42:37Z",
+    "2021-02-12T17:52:34Z",
+    "2021-02-22T16:52:41Z",
+    "2021-03-03T00:05:25Z",
+    "2021-03-08T15:57:35Z",
+    "2021-03-17T17:00:12Z",
+    "2021-03-25T09:25:17Z",
+    "2021-04-14T08:51:06Z",
+    "2021-04-15T07:26:55Z",
+    "2021-04-20T16:13:52Z",
+    "2021-04-26T14:07:56Z",
+    "2021-04-30T18:08:14Z",
+    "2021-05-28T10:46:11Z",
+    "2021-06-01T20:52:00Z",
+    "2021-06-14T07:26:29Z",
+    "2021-06-15T19:24:23Z",
+    "2021-06-24T15:40:55Z",
+    "2021-07-29T14:49:44Z",
+    "2021-08-04T18:10:17Z",
+    "2021-08-13T15:05:39Z",
+    "2021-08-16T23:19:02Z",
+    "2021-09-07T14:37:42Z",
+    "2021-09-16T09:56:17Z",
+    "2021-09-21T16:26:30Z",
+    "2021-10-01T10:11:50Z",
+    "2021-10-19T17:52:14Z",
+    "2021-10-24T01:23:36Z",
+    "2021-11-08T21:13:53Z",
+    "2021-11-15T20:56:12Z",
+    "2021-12-20T22:55:19Z",
+    "2022-01-13T17:34:27Z",
+    "2022-02-11T12:43:21Z",
+    "2022-03-19T16:22:15Z",
+    "2022-03-25T01:55:40Z",
+    "2022-04-17T23:57:53Z",
+    "2022-04-29T15:09:50Z",
+    "2022-05-16T07:35:16Z",
+    "2022-05-20T15:20:18Z",
+    "2022-05-22T13:23:34Z",
+    "2022-07-02T18:52:24Z",
+    "2022-07-31T01:09:26Z",
+    "2022-08-31T18:12:17Z",
+    "2022-09-27T04:38:05Z",
+    "2022-09-28T16:57:39Z",
+    "2022-09-30T13:38:09Z",
+    "2022-10-06T20:44:17Z",
+    "2022-10-10T22:41:12Z",
+    "2022-10-12T16:54:21Z",
+    "2022-11-27T14:50:12Z",
+    "2022-12-02T18:02:55Z",
+    "2022-12-20T19:38:18Z",
+    "2022-12-27T04:02:13Z",
+    "2023-01-13T00:26:03Z",
+    "2023-01-13T22:33:46Z",
+    "2023-01-14T08:05:33Z",
+    "2023-01-18T22:07:33Z",
+    "2023-02-10T13:56:11Z",
+    "2023-02-14T21:13:55Z",
+    "2023-02-16T16:55:43Z",
+    "2023-02-19T10:16:18Z",
+    "2023-03-13T18:14:30Z",
+    "2023-04-07T21:43:41Z",
+    "2023-04-15T04:07:31Z",
+    "2023-05-01T16:58:37Z",
+    "2023-05-12T21:55:47Z",
+    "2023-05-13T14:31:35Z",
+    "2023-05-21T18:30:09Z",
+    "2023-06-17T14:32:44Z",
+    "2023-06-18T13:12:07Z",
+    "2023-07-06T16:00:32Z",
+    "2023-08-29T14:03:48Z",
+    "2023-11-02T02:15:25Z",
+    "2023-11-08T16:58:07Z",
+    "2023-11-14T10:19:47Z",
+    "2023-11-15T15:53:18Z",
+    "2023-12-19T11:18:55Z",
+    "2024-04-17T18:30:49Z",
+    "2024-05-07T03:09:57Z",
+    "2024-05-13T17:43:38Z",
+    "2024-05-15T00:54:50Z",
+    "2024-05-20T17:21:55Z",
+    "2024-05-31T11:05:14Z",
+    "2024-06-20T22:51:20Z",
+    "2024-07-12T17:45:26Z",
+    "2024-08-13T16:00:16Z",
+    "2024-08-21T05:50:26Z",
+    "2024-08-21T18:01:04Z",
+    "2024-09-11T04:51:24Z",
+    "2024-10-20T19:07:10Z",
+    "2024-12-22T08:46:15Z",
+    "2025-02-25T19:07:03Z",
+    "2025-03-20T21:45:01Z",
+    "2025-04-04T01:57:54Z",
+    "2025-04-04T12:35:23Z",
+    "2025-04-30T04:58:47Z",
+    "2025-05-02T18:33:21Z",
+    "2025-05-31T19:40:53Z",
+    "2025-07-17T11:02:46Z",
+    "2025-08-22T21:01:22Z",
+    "2025-08-23T06:19:26Z",
+    "2025-09-06T06:49:28Z",
+    "2025-09-22T22:10:42Z",
+    "2025-09-23T23:02:04Z",
+    "2025-09-24T18:54:24Z",
+    "2025-10-10T01:46:48Z",
+    "2025-10-29T09:15:20Z",
+    "2025-11-10T14:34:27Z",
+    "2025-11-13T20:39:03Z",
+    "2025-11-15T18:48:14Z",
+    "2025-11-25T19:29:26Z",
+    "2025-12-03T14:04:37Z",
+    "2025-12-22T12:25:21Z",
+    "2026-01-09T13:23:03Z",
+    "2026-01-14T21:23:05Z",
+    "2026-01-16T23:16:48Z",
+    "2026-01-26T13:02:52Z",
+    "2026-01-27T17:33:33Z",
+    "2026-01-31T07:34:06Z",
+    "2026-02-03T23:41:12Z",
+    "2026-02-10T20:46:20Z",
+    "2026-03-06T02:39:04Z",
+    "2026-03-06T21:46:08Z",
+    "2026-03-09T03:15:15Z",
+    "2026-03-09T14:40:11Z",
+    "2026-03-11T05:57:59Z",
+    "2026-03-21T08:43:29Z",
+    "2026-03-26T16:11:36Z",
+    "2026-03-31T16:12:39Z",
+    "2026-04-03T00:29:32Z",
+    "2026-04-03T12:15:11Z",
+    "2026-04-03T15:19:07Z",
+    "2026-04-05T19:40:55Z",
+    "2026-04-07T15:53:29Z",
+    "2026-04-09T16:16:25Z",
+    "2026-04-12T17:09:43Z",
+    "2026-04-18T10:06:20Z",
+    "2026-04-19T03:07:55Z",
+    "2026-04-21T04:15:23Z",
+    "2026-04-23T03:20:28Z",
+    "2026-04-26T06:34:30Z",
+    "2026-04-28T15:43:30Z",
+    "2026-05-03T05:49:05Z",
+    "2026-05-06T19:58:40Z",
+    "2026-05-07T15:01:59Z"
+  ],
+  "stargazer_locations": [
+    "Costa Rica",
+    "Seattle",
+    "Sydney, Australia",
+    "Hilbert Space",
+    "Texas",
+    "Seattle WA",
+    "Chicago",
+    "Toronto, Ontario, Canada",
+    "MTL",
+    "Fortaleza",
+    "London",
+    "Brazil, Minas Gerais, Alfenas"
+  ]
+}

--- a/traffic-data/summary.json
+++ b/traffic-data/summary.json
@@ -1143,5 +1143,126 @@
         "uniques": 29
       }
     ]
+  },
+  {
+    "date": "2026-05-07",
+    "views_count": 0,
+    "views_uniques": 0,
+    "clones_count": 0,
+    "clones_uniques": 0,
+    "top_referrers": [
+      {
+        "referrer": "Bing",
+        "count": 246,
+        "uniques": 56
+      },
+      {
+        "referrer": "statics.teams.cdn.office.net",
+        "count": 125,
+        "uniques": 54
+      },
+      {
+        "referrer": "github.com",
+        "count": 116,
+        "uniques": 40
+      },
+      {
+        "referrer": "teams.public.onecdn.static.microsoft",
+        "count": 47,
+        "uniques": 16
+      },
+      {
+        "referrer": "learn.microsoft.com",
+        "count": 43,
+        "uniques": 20
+      },
+      {
+        "referrer": "Google",
+        "count": 30,
+        "uniques": 18
+      },
+      {
+        "referrer": "engage.cloud.microsoft",
+        "count": 24,
+        "uniques": 4
+      },
+      {
+        "referrer": "linkedin.com",
+        "count": 9,
+        "uniques": 5
+      },
+      {
+        "referrer": "teams.df.onecdn.static.microsoft",
+        "count": 8,
+        "uniques": 2
+      },
+      {
+        "referrer": "community.spiceworks.com",
+        "count": 5,
+        "uniques": 2
+      }
+    ],
+    "top_paths": [
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+        "title": "/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+        "count": 122,
+        "uniques": 70
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+        "title": "/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+        "count": 97,
+        "uniques": 57
+      },
+      {
+        "path": "/microsoft/FastTrack",
+        "title": "Overview",
+        "count": 88,
+        "uniques": 57
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples",
+        "title": "/tree/master/copilot-analytics-samples",
+        "count": 79,
+        "uniques": 50
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents",
+        "title": "/tree/master/copilot-agent-samples/copilot-studio-agents",
+        "count": 63,
+        "uniques": 47
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+        "title": "/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+        "count": 59,
+        "uniques": 34
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples",
+        "title": "/tree/master/copilot-agent-samples",
+        "count": 47,
+        "uniques": 31
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+        "title": "/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+        "count": 41,
+        "uniques": 29
+      },
+      {
+        "path": "/microsoft/FastTrack/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+        "title": "/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+        "count": 40,
+        "uniques": 26
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/scripts/Update-VivaEngageLicensingToggle",
+        "title": "/tree/master/scripts/Update-VivaEngageLicensingToggle",
+        "count": 34,
+        "uniques": 23
+      }
+    ]
   }
 ]

--- a/traffic-data/summary.json
+++ b/traffic-data/summary.json
@@ -1264,5 +1264,126 @@
         "uniques": 23
       }
     ]
+  },
+  {
+    "date": "2026-05-08",
+    "views_count": 0,
+    "views_uniques": 0,
+    "clones_count": 0,
+    "clones_uniques": 0,
+    "top_referrers": [
+      {
+        "referrer": "Bing",
+        "count": 246,
+        "uniques": 56
+      },
+      {
+        "referrer": "statics.teams.cdn.office.net",
+        "count": 125,
+        "uniques": 54
+      },
+      {
+        "referrer": "github.com",
+        "count": 116,
+        "uniques": 40
+      },
+      {
+        "referrer": "teams.public.onecdn.static.microsoft",
+        "count": 47,
+        "uniques": 16
+      },
+      {
+        "referrer": "learn.microsoft.com",
+        "count": 43,
+        "uniques": 20
+      },
+      {
+        "referrer": "Google",
+        "count": 30,
+        "uniques": 18
+      },
+      {
+        "referrer": "engage.cloud.microsoft",
+        "count": 24,
+        "uniques": 4
+      },
+      {
+        "referrer": "linkedin.com",
+        "count": 9,
+        "uniques": 5
+      },
+      {
+        "referrer": "teams.df.onecdn.static.microsoft",
+        "count": 8,
+        "uniques": 2
+      },
+      {
+        "referrer": "community.spiceworks.com",
+        "count": 5,
+        "uniques": 2
+      }
+    ],
+    "top_paths": [
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+        "title": "/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+        "count": 122,
+        "uniques": 70
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+        "title": "/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+        "count": 97,
+        "uniques": 57
+      },
+      {
+        "path": "/microsoft/FastTrack",
+        "title": "Overview",
+        "count": 88,
+        "uniques": 57
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples",
+        "title": "/tree/master/copilot-analytics-samples",
+        "count": 79,
+        "uniques": 50
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents",
+        "title": "/tree/master/copilot-agent-samples/copilot-studio-agents",
+        "count": 63,
+        "uniques": 47
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+        "title": "/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+        "count": 59,
+        "uniques": 34
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples",
+        "title": "/tree/master/copilot-agent-samples",
+        "count": 47,
+        "uniques": 31
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+        "title": "/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+        "count": 41,
+        "uniques": 29
+      },
+      {
+        "path": "/microsoft/FastTrack/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+        "title": "/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+        "count": 40,
+        "uniques": 26
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/scripts/Update-VivaEngageLicensingToggle",
+        "title": "/tree/master/scripts/Update-VivaEngageLicensingToggle",
+        "count": 34,
+        "uniques": 23
+      }
+    ]
   }
 ]

--- a/traffic-data/summary.json
+++ b/traffic-data/summary.json
@@ -1385,5 +1385,126 @@
         "uniques": 23
       }
     ]
+  },
+  {
+    "date": "2026-05-09",
+    "views_count": 0,
+    "views_uniques": 0,
+    "clones_count": 0,
+    "clones_uniques": 0,
+    "top_referrers": [
+      {
+        "referrer": "Bing",
+        "count": 205,
+        "uniques": 54
+      },
+      {
+        "referrer": "statics.teams.cdn.office.net",
+        "count": 142,
+        "uniques": 55
+      },
+      {
+        "referrer": "github.com",
+        "count": 129,
+        "uniques": 41
+      },
+      {
+        "referrer": "teams.public.onecdn.static.microsoft",
+        "count": 64,
+        "uniques": 23
+      },
+      {
+        "referrer": "learn.microsoft.com",
+        "count": 41,
+        "uniques": 19
+      },
+      {
+        "referrer": "Google",
+        "count": 30,
+        "uniques": 18
+      },
+      {
+        "referrer": "engage.cloud.microsoft",
+        "count": 22,
+        "uniques": 3
+      },
+      {
+        "referrer": "teams.df.onecdn.static.microsoft",
+        "count": 10,
+        "uniques": 3
+      },
+      {
+        "referrer": "linkedin.com",
+        "count": 8,
+        "uniques": 7
+      },
+      {
+        "referrer": "community.spiceworks.com",
+        "count": 5,
+        "uniques": 2
+      }
+    ],
+    "top_paths": [
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+        "title": "/tree/master/copilot-analytics-samples/Copilot_Audit_PBI",
+        "count": 116,
+        "uniques": 68
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+        "title": "/tree/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent",
+        "count": 102,
+        "uniques": 58
+      },
+      {
+        "path": "/microsoft/FastTrack",
+        "title": "Overview",
+        "count": 89,
+        "uniques": 59
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples",
+        "title": "/tree/master/copilot-analytics-samples",
+        "count": 73,
+        "uniques": 44
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples/copilot-studio-agents",
+        "title": "/tree/master/copilot-agent-samples/copilot-studio-agents",
+        "count": 63,
+        "uniques": 47
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+        "title": "/tree/master/copilot-analytics-samples/VivaInsights-Copilot-Dashboard-Sample",
+        "count": 63,
+        "uniques": 35
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-agent-samples",
+        "title": "/tree/master/copilot-agent-samples",
+        "count": 49,
+        "uniques": 32
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+        "title": "/tree/master/copilot-analytics-samples/copilot-usage-users-and-apps",
+        "count": 43,
+        "uniques": 31
+      },
+      {
+        "path": "/microsoft/FastTrack/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+        "title": "/blob/master/copilot-agent-samples/copilot-studio-agents/ca-PowerClawAgent/skills/workplace-intelligence-monitor.md",
+        "count": 40,
+        "uniques": 26
+      },
+      {
+        "path": "/microsoft/FastTrack/tree/master/scripts/Update-VivaEngageLicensingToggle",
+        "title": "/tree/master/scripts/Update-VivaEngageLicensingToggle",
+        "count": 32,
+        "uniques": 22
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This pull request updates the M365 Copilot Agents Cost Calculator tool and its supporting documentation to align with the latest (May 2026) Microsoft Copilot Studio licensing and pricing changes. It introduces support for new pricing models, adds new agent templates, and expands the set of supported language models. The automation workflows are also improved to streamline PR creation and use the correct tokens.

**Major updates to pricing models and documentation:**

* Added support for Copilot Credit Pre-Purchase Plan (P3) with 9 tiers and Microsoft Agent Pre-Purchase Plan (P3) with 3 tiers, reflecting the May 2026 licensing guide. Updated all relevant UI, tooltips, and documentation to explain these options and their effective rates. 

**Enhancements to agent templates and quick start options:**

* Added new "Employee Self-Service" agent templates for HR and IT scenarios in both the HTML tool and the documentation. 
**Expanded language model support:**

* Introduced new GPT-5.4 model variants (nano, mini, base, Pro) to the model selection UI and pricing descriptions. 

**Documentation and usability improvements:**

* Updated the quick start guide and references to reflect the new main HTML file name (`AgentCosTest.html` instead of `index.html`). 
* Clarified and expanded pricing model explanations throughout the guide, including new sections for voice agents and detailed model descriptions. 

**CI/CD workflow improvements:**

* Updated GitHub Actions workflows to use the correct secret token (`TRAFFIC_TOKEN`), grant `pull-requests: write` permission, and automatically create and auto-merge PRs for weekly updates. 

These changes ensure the cost calculator tool is up-to-date with the latest Microsoft licensing, provides more accurate estimates, and streamlines maintenance workflows.