### PR TITLE
Remove estimator comparison section entirely from cost tool README

### DIFF
--- a/copilot-agent-strategy/copilot-agents-cost-tool/README.md
+++ b/copilot-agent-strategy/copilot-agents-cost-tool/README.md
@@ -52,12 +52,6 @@ Open `AgentCosTest.html` in any modern browser — no server, no dependencies, n
 
 ---
 
-## What makes this tool different from Microsoft's official estimator
-
-Microsoft provides the [Copilot Studio agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/) for Copilot Credits forecasting.
-
----
-
 ## Billing rates reference
 
 ### Copilot Studio / M365 Copilot agents


### PR DESCRIPTION
Remove the 'What makes this tool different from Microsoft's official estimator' heading and remaining text, as the comparison table it accompanied was already removed.


