### PR TITLE
Updates to Engage scripts to bring them into 2026

### DIFF
--- a/resource-stats.json
+++ b/resource-stats.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T18:20:40.181Z",
+  "generatedAt": "2026-07-22T13:39:52.431Z",
   "sources": {
     "views": "clarity",
     "upvotes": "github-discussions"
@@ -23,7 +23,12 @@
     },
     "powerclaw-agent": {
       "views": 1632,
-      "viewsUniques": 961
+      "viewsUniques": 961,
+      "upvotes": 0,
+      "discussion": {
+        "number": 479,
+        "url": "https://github.com/microsoft/FastTrack/discussions/479"
+      }
     },
     "purview-audit-copilot-report": {
       "views": 656,


### PR DESCRIPTION
Audited all Viva Engage/Yammer scripts in scripts/ for outdated/deprecated API usage and migrated what's migratable to Microsoft Graph.

Migrated to Microsoft Graph (app-only, client-credentials auth)
Delete-YammerGroups → Delete-EngageGroups — DELETE /beta/employeeExperience/communities/{id}
Add-YammerGroupAdmins → Add-EngageGroupAdmins — POST /groups/{id}/owners/$ref
Get-YammerGroupInfo → Get-EngageGroupInfo — communities list + group member count + group owners (dropped LastMessageAt, no Graph equivalent)
⚠️ Breaking change: legacy numeric Yammer group IDs don't map to Graph community/group IDs — existing input CSVs need regenerating (see each README).

Renamed only (endpoints unchanged, still current/documented)
Export-YammerNetworkData → Export-EngageNetworkData — removed -IncludeExternalNetworks (not supported for native-mode networks); added runtime warning for -IncludeFiles All
Export-YammerFiles → Export-EngageFiles — added native-mode limitation warning
Both reference the confirmed March 13, 2026 admin center retirement (MC1230453).

Rewritten (scope change)
Delete-YammerUsers → Delete-EngageUsers — previously deleted the user's Yammer account entirely via the legacy API; no Graph equivalent exists for that. Rewritten to remove a user from a specific M365 group/community (DELETE /groups/{id}/members/{id}/$ref). CSV format changed from UserID to GroupID + Email.
No migration possible
Delete-AllCommunityPosts — Graph's communities API has no endpoint for reading/deleting message content. Left on the legacy Yammer REST API; documented as a permanent dependency until Microsoft ships one.
All scripts validated via PowerShell AST parsing. Delete-EngageGroups and Add-EngageGroupAdmins were also live-tested end-to-end against a test tenant.