### PR TITLE
Fix PR sweeper: stop expanding pull_request.body inside a run comment

### DIFF
--- a/.github/workflows/pr-sweeper.yml
+++ b/.github/workflows/pr-sweeper.yml
@@ -93,10 +93,12 @@ jobs:
           IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
-          # NOTE: The PR body is deliberately NOT captured. Interpolating
-          # ${{ github.event.pull_request.body }} into a shell step is a
+          # NOTE: The PR body is deliberately NOT captured. Interpolating the
+          # pull_request.body context value into a shell step is a
           # script-injection sink, and nothing downstream needs the body.
-          # Every value below is passed via env and JSON-encoded by jq --arg.
+          # (Do not write that context expression here either: GitHub expands
+          # it before bash runs, even inside a comment.) Every value below is
+          # passed via env and JSON-encoded by jq --arg.
           jq -n \
             --arg number "$PR_NUMBER" \
             --arg title "$PR_TITLE" \


### PR DESCRIPTION
The "Write PR metadata" step warned that interpolating the PR body into a shell step is an injection sink, but it wrote the pull_request.body context expression (in ${{ }} form) inside a comment to say so. GitHub expands ${{ }} expressions textually before bash runs -- even inside a "#" comment -- so the PR body was injected into the generated script. On any PR whose body contained newlines this broke the step with exit code 127 ("$'\r': command not found").

Rewritten as literal "pull_request.body" text so nothing is expanded. The body is still deliberately never captured; all values continue to flow through env and jq --arg.


Copilot-Session: cecb163d-04c4-4b01-ab7a-14d25f7ec690


