### PR TITLE
Updating Insights script to resolve timeout

### DIFF
--- a/resource-stats.json
+++ b/resource-stats.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-22T13:39:52.431Z",
+  "generatedAt": "2026-07-22T14:45:16.697Z",
   "sources": {
     "views": "clarity",
     "upvotes": "github-discussions"


### PR DESCRIPTION
Problem: Script resolved each user's manager with 2 serial Graph calls per user (Get-MgUserManager + Get-MgUser). On tenants with thousands of licensed users, this meant tens of thousands of sequential HTTP calls — causing timeouts and throttling.

Fix:

Resolve manager UPNs via Microsoft Graph $batch requests, 20 users per call (~20x fewer round-trips)
Added automatic retry/backoff on HTTP 429 (throttled) responses
Added a progress indicator so long runs don't look hung
Fixed a bug where the script wrote EntraUsersExport.csv but told users to look for InsightsLicensedUsers.csv — now consistently uses InsightsLicensedUsers.csv