### PR TITLE
Present card upvotes as a display-only stat, not an upvote button

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,7 +638,7 @@
       text-align: right;
     }
     .compact-views, .compact-votes { display: none; }
-    .compact-views {
+    .compact-views, .compact-votes {
       align-items: center;
       gap: 0.25rem;
       color: var(--text-lighter);
@@ -2140,7 +2140,7 @@
           ${formatCount(stats.views)}
         </div>` : ''}
         ${stats.hasUpvotes ? `<div class="compact-votes" aria-label="${stats.upvotes} upvotes">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 15l-6-6-6 6"/></svg>
+          <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>
           <span class="vote-count">${formatCount(stats.upvotes)}</span>
         </div>` : ''}
         <div class="card-footer">
@@ -2154,7 +2154,7 @@
               ${formatCount(stats.views)}
             </span>` : ''}
             ${stats.hasUpvotes ? `<span class="stat-views" aria-label="${stats.upvotes} upvotes">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 15l-6-6-6 6"/></svg>
+              <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>
               <span class="vote-count">${formatCount(stats.upvotes)}</span>
             </span>` : ''}
           </div>


### PR DESCRIPTION
## What
Makes the resource-card **upvote count read as a passive stat** (like the views count) instead of looking like an inline upvote button.

## Why
In the current design, upvotes are backed by **GitHub Discussion reactions** (giscus on the detail page) — `hasUpvotes = hasDiscussion` and the count comes from server-side stats. So the number shown on cards is **display-only**; real upvoting happens via giscus after opening a resource. Two things made the card count misleadingly look like a clickable upvote control:

1. The up-chevron icon universally reads as an "upvote" affordance (Reddit/HN/StackOverflow).
2. `.compact-votes` (list view) was missing the muted styling that `.compact-views` has, so the number rendered in the default darker/bolder text.

Users clicked it expecting to upvote; instead it opened the detail page and nothing "saved."

## Fix
- Swap the up-chevron for a muted heart-outline metric icon (same hollow line-icon style as the views "eye").
- Share the muted stat styling between `.compact-views` and `.compact-votes` so the upvote count matches the views count exactly (color, size, mono font).

Clicking the card still opens the detail page, where giscus voting lives. Real voting is unchanged.

## Verification
Verified in a real browser (headless Chromium):
- List view: upvote count now renders in the same muted grey / 12px / mono as views; no up-chevron remains.
- Clicking the count opens the resource detail page (where giscus reactions live).
- No button/border/hover affordance added.

Single-file change: `index.html` (+3 / -3).