### PR TITLE
Fix Engaging sort to rank by reaction count

### DIFF
--- a/index.html
+++ b/index.html
@@ -1876,10 +1876,9 @@
         } else if (state.sort === 'new') {
           return new Date(b.updated) - new Date(a.updated);
         } else if (state.sort === 'engaging') {
-          const rateA = (statsA.upvotes + 2) / (statsA.views + 40);
-          const rateB = (statsB.upvotes + 2) / (statsB.views + 40);
-          if (rateB !== rateA) return rateB - rateA;
-          return statsB.upvotes - statsA.upvotes;
+          if (statsA.upvotes !== statsB.upvotes) return statsB.upvotes - statsA.upvotes;
+          if (statsA.views !== statsB.views) return statsB.views - statsA.views;
+          return a.name.localeCompare(b.name);
         }
         return 0;
       });

--- a/tools/catalog-build/build-stats.js
+++ b/tools/catalog-build/build-stats.js
@@ -325,12 +325,10 @@ function mapDiscussions(discussions, knownSlugs, explicitMap) {
         discussions.find(item => item.title.includes(slug));
     }
     if (!discussion) continue;
-    const thumbsUp = discussion.reactionGroups?.find(group => group.content === 'THUMBS_UP');
-    const count = thumbsUp?.reactors?.totalCount;
-    if (!Number.isInteger(count) || count < 0) {
-      console.warn(`Warning: discussion #${discussion.number} has no THUMBS_UP count.`);
-      continue;
-    }
+    const count = (discussion.reactionGroups ?? []).reduce((sum, group) => {
+      const total = group?.reactors?.totalCount;
+      return sum + (Number.isInteger(total) && total > 0 ? total : 0);
+    }, 0);
     result.set(slug, {
       upvotes: count,
       discussion: { number: discussion.number, url: discussion.url }


### PR DESCRIPTION
## Problem

Sorting the catalog by **Engaging** never surfaced highly-reacted resources. PowerClaw — the only resource with a reaction — stayed near the bottom instead of the top.

Two root causes:

1. **Rate-based sort buried high-traffic resources.** "Engaging" used a smoothed upvotes-per-view rate `(upvotes + 2) / (views + 40)`. With 1,632 views, a single reaction produces a microscopic rate, so PowerClaw sank below low-traffic resources that had zero reactions.
2. **Only THUMBS_UP counted.** `build-stats.js` counted only `THUMBS_UP` reactions as upvotes, so any other reaction (heart, rocket, tada, eyes ...) was ignored entirely.

## Changes

- **`index.html`** — "Engaging" now ranks by raw reaction/upvote count descending, with views as a tiebreaker, then name.
- **`tools/catalog-build/build-stats.js`** — `mapDiscussions` now sums reactors across **all** reaction groups, not just `THUMBS_UP`. The `upvotes` field name is unchanged (now represents total reactions), so nothing downstream changes.

## Notes

`resource-stats.json` still needs a fresh `traffic-stats` workflow run to pick up the new reaction totals; after that, reacted resources will sort to the top of Engaging.