### PR TITLE
chore: rebuild catalog [skip ci]

### DIFF
--- a/resource-stats.json
+++ b/resource-stats.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-22T14:48:12.364Z",
+  "generatedAt": "2026-07-27T19:00:31.864Z",
   "sources": {
     "views": "clarity",
     "upvotes": "github-discussions"
@@ -11,11 +11,16 @@
     },
     "ai-council": {
       "views": 78,
-      "viewsUniques": 61
+      "viewsUniques": 61,
+      "upvotes": 0,
+      "discussion": {
+        "number": 501,
+        "url": "https://github.com/microsoft/FastTrack/discussions/501"
+      }
     },
     "autoreply-agent": {
-      "views": 69,
-      "viewsUniques": 46
+      "views": 1,
+      "viewsUniques": 1
     },
     "copilot-agents-guide": {
       "views": 32,
@@ -24,15 +29,20 @@
     "powerclaw-agent": {
       "views": 1632,
       "viewsUniques": 961,
-      "upvotes": 0,
+      "upvotes": 1,
       "discussion": {
         "number": 479,
         "url": "https://github.com/microsoft/FastTrack/discussions/479"
       }
     },
     "purview-audit-copilot-report": {
-      "views": 656,
-      "viewsUniques": 382
+      "views": 2,
+      "viewsUniques": 1,
+      "upvotes": 0,
+      "discussion": {
+        "number": 497,
+        "url": "https://github.com/microsoft/FastTrack/discussions/497"
+      }
     },
     "viva-insights-copilot-dashboard": {
       "views": 119,

--- a/traffic-data/clarity-views.json
+++ b/traffic-data/clarity-views.json
@@ -1,4 +1,35 @@
 {
-  "lastRun": "",
-  "days": {}
+  "lastRun": "2026-07-27",
+  "days": {
+    "2026-07-27": {
+      "autoreply-agent": {
+        "views": 1,
+        "uniques": 1
+      },
+      "purview-audit-copilot-report": {
+        "views": 2,
+        "uniques": 1
+      }
+    },
+    "2026-07-26": {
+      "autoreply-agent": {
+        "views": 0,
+        "uniques": 0
+      },
+      "purview-audit-copilot-report": {
+        "views": 0,
+        "uniques": 0
+      }
+    },
+    "2026-07-25": {
+      "autoreply-agent": {
+        "views": 0,
+        "uniques": 0
+      },
+      "purview-audit-copilot-report": {
+        "views": 0,
+        "uniques": 0
+      }
+    }
+  }
 }


### PR DESCRIPTION
First catalog rebuild to land since branch protection started rejecting direct pushes
to master.

The publish job had been pushing generated files straight to master and failing with
`GH006: Protected branch update failed`. Runs that appeared green only got there through
the "no changes" early exit, so the catalog quietly stopped updating.

Fixed in #502: the job now escalates from direct push, to rebase and retry, to this
branch-plus-PR fallback. This branch is that fallback firing for the first time.

**Changes:**
- `resource-stats.json` — +17 / -7
- `traffic-data/clarity-views.json` — +33 / -2

Both are generated artifacts. No hand edits.

The job also attempted to open this PR automatically and was blocked by the same Actions
PR policy, so it exited 0 with a warning and the compare URL rather than failing red.
Setting `AUTOMATION_PAT` makes it self-service.