### PR TITLE
chore(deps): bump js-yaml to 5.2.2 in catalog-build (GHSA-pm4m-ph32-ghv5)

### DIFF
--- a/tools/catalog-build/package-lock.json
+++ b/tools/catalog-build/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "gray-matter": "^4.0.3",
-        "js-yaml": "^5.2.1"
+        "js-yaml": "^5.2.2"
       }
     },
     "node_modules/argparse": {
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/tools/catalog-build/package.json
+++ b/tools/catalog-build/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "gray-matter": "^4.0.3",
-    "js-yaml": "^5.2.1"
+    "js-yaml": "^5.2.2"
   }
 }


### PR DESCRIPTION
Bumps `js-yaml` in `tools/catalog-build` from 5.2.1 to 5.2.2, closing Dependabot alert #154.

## The advisory

[GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) - High, CVSS 7.5. Exponential parsing time in flow collections leads to denial of service. Affects `>= 5.0.0, <= 5.2.1`, fixed in 5.2.2.

## Why it matters here

`js-yaml` is the front-matter engine for the catalog build (`tools/catalog-build/index.js`, `yaml.load` inside the gray-matter parser). `build-catalog.yml` runs on `pull_request` and parses markdown from the sample directories, so a crafted front-matter block in a contributed file could stall that job. Dev dependency only, nothing ships to consumers, and the workflow runs with `contents: read` and no secrets, so this is burned CI minutes rather than an exposure. Still worth patching.

## What changed upstream

The 5.2.1...5.2.2 diff is the parser fix plus a regression test: the parser now wraps already-parsed key events in a synthetic flow mapping instead of rewinding and reparsing flow sequence pair keys. No API surface change.

## Validation

`npm ci` and `npm run check` both pass against the regenerated lockfile.