### PR TITLE
Fixes for REQ/RITM scenarios and install issues

### DIFF
--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/README.md
@@ -112,7 +112,7 @@ The solution ships both flows plus its own ServiceNow connection reference
    - You will **not** be asked to map a Dataverse connection. The flows bind Dataverse through `new_sharedcommondataserviceforapps_41c83`, which is already in your environment courtesy of the ServiceNow extension pack.
 5. Select **Import** and wait for the success banner.
 
-#### B3 — Identify the two packaged workflow IDs
+#### B2 — Identify the two packaged workflow IDs
 
 1. In [Power Automate](https://make.powerautomate.com), select **Solutions**, then open **ESS ServiceNow ITSM - Get Request Details**.
 2. Confirm both flows show **Status: On**. If either is **Off**, open it and select **Turn on**.
@@ -131,7 +131,7 @@ The solution ships both flows plus its own ServiceNow connection reference
    Copilot Studio `InvokeFlowAction`. Keep the two packaged IDs straight: swapping them sends REQ
    lookups to the RITM flow and vice versa, which fails silently with an empty card rather than an error.
 
-#### B4 — Create the three topics
+#### B3 — Create the three topics
 
 For each file in `topics/`:
 
@@ -146,7 +146,7 @@ For each file in `topics/`:
    | `ess-it-servicenow-itsm-system-get-request-item.mcs.yml` | `ESS IT ServiceNow ITSM System Get Request Item` |
    | `servicenow-itsm-get-request-details.mcs.yml` | `ESS ServiceNow ITSM Get Request Details` |
 
-5. In each **system** topic, replace `{FLOW_GUID}` with that topic's matching packaged workflow ID from B3:
+5. In each **system** topic, replace `{FLOW_GUID}` with that topic's matching packaged workflow ID from B2:
    - `…system-get-request-details` → ID of **Get Request Details**
    - `…system-get-request-item` → ID of **Get Request Item**
 6. In the **user-facing** topic, replace both `dialog:` values with the PascalCase schema names the portal generated:
@@ -160,23 +160,23 @@ For each file in `topics/`:
    `Dialog with id '…' not found` at publish — see the note under [Files](#-files).
 7. **Save** each topic.
 
-#### B5 — Publish
+#### B4 — Publish
 
 Select **Publish** in Copilot Studio. If publish reports `Dialog with id … not found`, revisit
-step B4.6; if it reports `IncorrectTypeAssignment` alongside it, that's the same fault, not a
+step B3.6; if it reports `IncorrectTypeAssignment` alongside it, that's the same fault, not a
 second one.
 
 > The solution declares the ServiceNow connection as `"runtimeSource": "invoker"`, so an imported
-> flow is wired for OBO from the start. You still need the connection-side step in B6.
+> flow is wired for OBO from the start. You still need the connection-side step in B5.
 
-#### B6 — Configure OBO (do this after publishing, before testing)
+#### B5 — Configure OBO (do this after publishing, before testing)
 
 Both flows call ServiceNow **as the signed-in employee**, which requires parameter sharing on the
 ServiceNow connection. This is configured in **Copilot Studio**, not Power Automate — follow
 [Configure OBO](#-configure-obo-required) below.
 
 > Publish the agent first. The imported flows do not appear under **Settings** → **Connection settings**
-> until the agent has been published, so you cannot configure their connection parameters before B5.
+> until the agent has been published, so you cannot configure their connection parameters before B4.
 
 ### 🔗 Set the portal base URI (required for links)
 

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/README.md
@@ -266,3 +266,9 @@ running as the maker and every user will see the maker's data — reconfigure be
 | Author | Original Publish Date | Latest Publish Date |
 | --- | --- | --- |
 | Dean Cron | 2026-07-30 | 2026-08-03 |
+
+## Disclaimer
+
+THIS CODE IS PROVIDED AS IS WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED
+WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR
+NON-INFRINGEMENT.

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/README.md
@@ -112,26 +112,24 @@ The solution ships both flows plus its own ServiceNow connection reference
    - You will **not** be asked to map a Dataverse connection. The flows bind Dataverse through `new_sharedcommondataserviceforapps_41c83`, which is already in your environment courtesy of the ServiceNow extension pack.
 5. Select **Import** and wait for the success banner.
 
-#### B2 — Configure OBO (do this before testing)
-
-Both flows call ServiceNow **as the signed-in employee**, which requires parameter sharing on the
-ServiceNow connection. This is configured in **Copilot Studio**, not Power Automate — follow
-[Configure OBO](#-configure-obo-required) below, then return here.
-
-#### B3 — Collect the two flow IDs
+#### B3 — Identify the two packaged workflow IDs
 
 1. In [Power Automate](https://make.powerautomate.com), select **Solutions**, then open **ESS ServiceNow ITSM - Get Request Details**.
 2. Confirm both flows show **Status: On**. If either is **Off**, open it and select **Turn on**.
    - `ESS IT ServiceNow ITSM Get Request Details`
    - `ESS IT ServiceNow ITSM Get Request Item`
-3. Open each flow and read its ID from the browser address bar — it's the GUID immediately after `/flows/`:
+3. Use these packaged workflow IDs in the matching system topics:
 
    ```text
-   https://make.powerautomate.com/environments/{env}/solutions/{sol}/flows/5750fc72-738f-412c-b9cb-5094507f2eb2/details
-                                                                           └──────────── flow ID ────────────┘
+   Get Request Details: 5750fc72-738f-412c-b9cb-5094507f2eb2
+   Get Request Item:    917c7b14-8bcb-4492-bf4a-eb52cfadbc3d
    ```
 
-   Record one ID per flow — they are different values. Keep them straight by flow name: swapping them sends REQ lookups to the RITM flow and vice versa, which fails silently with an empty card rather than an error.
+   Do **not** copy the GUID from either Power Automate browser URL. Solution import creates a
+   generated Power Automate resource ID for each URL, which can look like a second standalone
+   flow. Each is the same imported flow, but it is **not** the Dataverse workflow ID used by the
+   Copilot Studio `InvokeFlowAction`. Keep the two packaged IDs straight: swapping them sends REQ
+   lookups to the RITM flow and vice versa, which fails silently with an empty card rather than an error.
 
 #### B4 — Create the three topics
 
@@ -148,7 +146,7 @@ For each file in `topics/`:
    | `ess-it-servicenow-itsm-system-get-request-item.mcs.yml` | `ESS IT ServiceNow ITSM System Get Request Item` |
    | `servicenow-itsm-get-request-details.mcs.yml` | `ESS ServiceNow ITSM Get Request Details` |
 
-5. In each **system** topic, replace `{FLOW_GUID}` with that topic's matching flow ID from B3:
+5. In each **system** topic, replace `{FLOW_GUID}` with that topic's matching packaged workflow ID from B3:
    - `…system-get-request-details` → ID of **Get Request Details**
    - `…system-get-request-item` → ID of **Get Request Item**
 6. In the **user-facing** topic, replace both `dialog:` values with the PascalCase schema names the portal generated:
@@ -169,7 +167,16 @@ step B4.6; if it reports `IncorrectTypeAssignment` alongside it, that's the same
 second one.
 
 > The solution declares the ServiceNow connection as `"runtimeSource": "invoker"`, so an imported
-> flow is wired for OBO from the start. You still need the connection-side step in B2.
+> flow is wired for OBO from the start. You still need the connection-side step in B6.
+
+#### B6 — Configure OBO (do this after publishing, before testing)
+
+Both flows call ServiceNow **as the signed-in employee**, which requires parameter sharing on the
+ServiceNow connection. This is configured in **Copilot Studio**, not Power Automate — follow
+[Configure OBO](#-configure-obo-required) below.
+
+> Publish the agent first. The imported flows do not appear under **Settings** → **Connection settings**
+> until the agent has been published, so you cannot configure their connection parameters before B5.
 
 ### 🔗 Set the portal base URI (required for links)
 

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
@@ -412,3 +412,9 @@ outputType:
       displayName: RelevantRequestFound
       type: Boolean
       examples:
+
+    ServiceNowData:
+      displayName: ServiceNowData
+      description: Request or request item details returned from ServiceNow.
+      type: String
+      examples:

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
@@ -218,6 +218,7 @@ beginDialog:
 
                             - kind: EndDialog
                               id: cancelAfterRitm
+                              clearTopicQueue: true
 
                       elseActions:
                         - kind: SendActivity
@@ -228,6 +229,7 @@ beginDialog:
 
                         - kind: EndDialog
                           id: cancelAfterRitmNotFound
+                          clearTopicQueue: true
 
               elseActions:
                 - kind: BeginDialog
@@ -366,6 +368,7 @@ beginDialog:
 
                         - kind: EndDialog
                           id: cancelAllDialogs
+                          clearTopicQueue: true
 
                   elseActions:
                     - kind: ConditionGroup

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
@@ -416,8 +416,3 @@ outputType:
       type: Boolean
       examples:
 
-    ServiceNowData:
-      displayName: ServiceNowData
-      description: Request or request item details returned from ServiceNow.
-      type: String
-      examples:

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
@@ -216,7 +216,7 @@ beginDialog:
                                         ]
                                       }
 
-                            - kind: CancelAllDialogs
+                            - kind: EndDialog
                               id: cancelAfterRitm
 
                       elseActions:
@@ -226,7 +226,7 @@ beginDialog:
                             text:
                               - I couldn't find a request item matching that RITM number. Please check the number and try again.
 
-                        - kind: CancelAllDialogs
+                        - kind: EndDialog
                           id: cancelAfterRitmNotFound
 
               elseActions:
@@ -364,7 +364,7 @@ beginDialog:
                                     ]
                                   }
 
-                        - kind: CancelAllDialogs
+                        - kind: EndDialog
                           id: cancelAllDialogs
 
                   elseActions:

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-request-details/topics/servicenow-itsm-get-request-details.mcs.yml
@@ -59,6 +59,8 @@ modelDescription: |-
   * "Where is my service request?"
   * "Has my software request been approved?"
   * "Check the status of my access request"
+
+  After displaying the adaptive card, treat the card as the complete response. Do not append a summary, offer more help, or ask a follow-up question.
 beginDialog:
   kind: OnRecognizedIntent
   id: main

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
@@ -95,7 +95,7 @@ The solution ships the flow plus its own ServiceNow connection reference
    - You will **not** be asked to map a Dataverse connection. The flow binds Dataverse through `new_sharedcommondataserviceforapps_41c83`, which is already in your environment courtesy of the ServiceNow extension pack.
 5. Select **Import** and wait for the success banner.
 
-#### B3 — Identify the packaged workflow ID
+#### B2 — Identify the packaged workflow ID
 
 1. In [Power Automate](https://make.powerautomate.com), select **Solutions**, then open **ESS ServiceNow ITSM - Get User Requests**.
 2. Confirm **ESS IT ServiceNow ITSM Get User Requests** shows **Status: On**. If it's **Off**, open it and select **Turn on**.
@@ -110,7 +110,7 @@ The solution ships the flow plus its own ServiceNow connection reference
    flow. It is the same imported flow, but it is **not** the Dataverse workflow ID used by the
    Copilot Studio `InvokeFlowAction`.
 
-#### B4 — Create the two topics
+#### B3 — Create the two topics
 
 For each file in `topics/`:
 
@@ -124,7 +124,7 @@ For each file in `topics/`:
    | `ess-it-servicenow-itsm-system-get-user-requests.mcs.yml` | `ESS IT ServiceNow ITSM System Get User Requests` |
    | `ess-it-servicenow-itsm-get-user-requests.mcs.yml` | `ESS IT ServiceNow ITSM Get User Requests` |
 
-5. In the **system** topic, replace `{FLOW_GUID}` with the packaged workflow ID from B3.
+5. In the **system** topic, replace `{FLOW_GUID}` with the packaged workflow ID from B2.
 6. In the **user-facing** topic, replace **both** `dialog:` values (they appear twice — once in the all-requests branch, once in the filtered branch) with the PascalCase schema name the portal generated:
 
    ```yaml
@@ -135,23 +135,23 @@ For each file in `topics/`:
    `Dialog with id '…' not found` at publish — see the note under [Files](#-files).
 7. **Save** each topic.
 
-#### B5 — Publish
+#### B4 — Publish
 
 Select **Publish** in Copilot Studio. If publish reports `Dialog with id … not found`, revisit
-step B4.6; if it reports `IncorrectTypeAssignment` alongside it, that's the same fault, not a
+step B3.6; if it reports `IncorrectTypeAssignment` alongside it, that's the same fault, not a
 second one.
 
 > The solution declares the ServiceNow connection as `"runtimeSource": "invoker"`, so an imported
-> flow is wired for OBO from the start. You still need the connection-side step in B6.
+> flow is wired for OBO from the start. You still need the connection-side step in B5.
 
-#### B6 — Configure OBO (do this after publishing, before testing)
+#### B5 — Configure OBO (do this after publishing, before testing)
 
 The flow calls ServiceNow **as the signed-in employee**, which requires parameter sharing on the
 ServiceNow connection. This is configured in **Copilot Studio**, not Power Automate — follow
 [Configure OBO](#-configure-obo-required) below.
 
 > Publish the agent first. The imported flow does not appear under **Settings** → **Connection settings**
-> until the agent has been published, so you cannot configure its connection parameters before B5.
+> until the agent has been published, so you cannot configure its connection parameters before B4.
 
 ### 🔗 Set the portal base URI (required for links)
 

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
@@ -244,3 +244,9 @@ rather than the sole isolation boundary. Note that the 15-minute cache is per-us
 | Author | Original Publish Date | Latest Publish Date |
 | --- | --- | --- |
 | Dean Cron | 2026-07-30 | 2026-08-03 |
+
+## Disclaimer
+
+THIS CODE IS PROVIDED AS IS WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED
+WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR
+NON-INFRINGEMENT.

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
@@ -95,16 +95,20 @@ The solution ships the flow plus its own ServiceNow connection reference
    - You will **not** be asked to map a Dataverse connection. The flow binds Dataverse through `new_sharedcommondataserviceforapps_41c83`, which is already in your environment courtesy of the ServiceNow extension pack.
 5. Select **Import** and wait for the success banner.
 
-#### B3 — Collect the flow ID
+#### B3 — Identify the packaged workflow ID
 
 1. In [Power Automate](https://make.powerautomate.com), select **Solutions**, then open **ESS ServiceNow ITSM - Get User Requests**.
 2. Confirm **ESS IT ServiceNow ITSM Get User Requests** shows **Status: On**. If it's **Off**, open it and select **Turn on**.
-3. Open the flow and read its ID from the browser address bar — it's the GUID immediately after `/flows/`:
+3. Use this packaged workflow ID in the system topic:
 
    ```text
-   https://make.powerautomate.com/environments/{env}/solutions/{sol}/flows/5f08a17c-ed32-42ea-bbe4-29da0e9e98b1/details
-                                                                           └──────────── flow ID ────────────┘
+   5f08a17c-ed32-42ea-bbe4-29da0e9e98b1
    ```
+
+   Do **not** copy the GUID from the Power Automate browser URL. Solution import creates a
+   generated Power Automate resource ID for that URL, which can look like a second standalone
+   flow. It is the same imported flow, but it is **not** the Dataverse workflow ID used by the
+   Copilot Studio `InvokeFlowAction`.
 
 #### B4 — Create the two topics
 
@@ -120,7 +124,7 @@ For each file in `topics/`:
    | `ess-it-servicenow-itsm-system-get-user-requests.mcs.yml` | `ESS IT ServiceNow ITSM System Get User Requests` |
    | `ess-it-servicenow-itsm-get-user-requests.mcs.yml` | `ESS IT ServiceNow ITSM Get User Requests` |
 
-5. In the **system** topic, replace `{FLOW_GUID}` with the flow ID from B3.
+5. In the **system** topic, replace `{FLOW_GUID}` with the packaged workflow ID from B3.
 6. In the **user-facing** topic, replace **both** `dialog:` values (they appear twice — once in the all-requests branch, once in the filtered branch) with the PascalCase schema name the portal generated:
 
    ```yaml

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/README.md
@@ -95,12 +95,6 @@ The solution ships the flow plus its own ServiceNow connection reference
    - You will **not** be asked to map a Dataverse connection. The flow binds Dataverse through `new_sharedcommondataserviceforapps_41c83`, which is already in your environment courtesy of the ServiceNow extension pack.
 5. Select **Import** and wait for the success banner.
 
-#### B2 — Configure OBO (do this before testing)
-
-The flow calls ServiceNow **as the signed-in employee**, which requires parameter sharing on the
-ServiceNow connection. This is configured in **Copilot Studio**, not Power Automate — follow
-[Configure OBO](#-configure-obo-required) below, then return here.
-
 #### B3 — Collect the flow ID
 
 1. In [Power Automate](https://make.powerautomate.com), select **Solutions**, then open **ESS ServiceNow ITSM - Get User Requests**.
@@ -144,7 +138,16 @@ step B4.6; if it reports `IncorrectTypeAssignment` alongside it, that's the same
 second one.
 
 > The solution declares the ServiceNow connection as `"runtimeSource": "invoker"`, so an imported
-> flow is wired for OBO from the start. You still need the connection-side step in B2.
+> flow is wired for OBO from the start. You still need the connection-side step in B6.
+
+#### B6 — Configure OBO (do this after publishing, before testing)
+
+The flow calls ServiceNow **as the signed-in employee**, which requires parameter sharing on the
+ServiceNow connection. This is configured in **Copilot Studio**, not Power Automate — follow
+[Configure OBO](#-configure-obo-required) below.
+
+> Publish the agent first. The imported flow does not appear under **Settings** → **Connection settings**
+> until the agent has been published, so you cannot configure its connection parameters before B5.
 
 ### 🔗 Set the portal base URI (required for links)
 

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
@@ -59,7 +59,7 @@ beginDialog:
               input:
                 binding:
                   IsActive: =Blank()
-                  UserIdentifier: =Global.ESS_UserContext_UPN
+                  UserIdentifier: =Coalesce(Global.ESS_UserContext_UPN, System.User.PrincipalName)
 
               dialog: msdyn_copilotforemployeeselfserviceit.topic.ess-it-servicenow-itsm-system-get-user-requests
               output:
@@ -77,7 +77,7 @@ beginDialog:
           input:
             binding:
               IsActive: =Topic.IsActive
-              UserIdentifier: =Global.ESS_UserContext_UPN
+              UserIdentifier: =Coalesce(Global.ESS_UserContext_UPN, System.User.PrincipalName)
 
           dialog: msdyn_copilotforemployeeselfserviceit.topic.ess-it-servicenow-itsm-system-get-user-requests
           output:

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
@@ -16,7 +16,7 @@ inputs:
 modelDescription: |-
   This tool retrieves the list of service catalog requests (REQ numbers) for the user.
 
-  Use this tool when a user asks about their service requests, catalog requests, or REQ items — NOT for incident tickets (INC). Use ServiceNow-ITSM-Get-User-Tickets for incidents.
+  Use this tool when a user asks about their requests, service requests, catalog requests, REQ items, or items they requested — NOT for incident tickets (INC), IT support tickets, helpdesk tickets, or support cases. If the user says "requests" without saying ticket, incident, INC, support, or helpdesk, treat it as a service catalog request and use this tool. Use ServiceNow-ITSM-Get-User-Tickets only for incidents or support tickets.
 
   Example queries:
   * "Show me my service requests"
@@ -36,7 +36,21 @@ modelDescription: |-
 beginDialog:
   kind: OnRecognizedIntent
   id: main
-  intent: {}
+  intent:
+    triggerQueries:
+      - show all my requests
+      - list all my requests
+      - show my requests
+      - list my requests
+      - show me my service requests
+      - list my service requests
+      - what requests do I have open
+      - show my open requests
+      - my pending catalog requests
+      - list my completed requests
+      - what did I request recently
+      - show my REQ items
+
   actions:
     - kind: ConditionGroup
       id: conditionGroup_requestState

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
@@ -39,17 +39,8 @@ beginDialog:
   intent: {}
   actions:
     - kind: ConditionGroup
-      id: conditionGroup_checkCache
+      id: conditionGroup_requestState
       conditions:
-        - id: conditionItem_useCache
-          condition: =!IsBlank(Global.ESS_ServiceNow_AllRequests) && !IsBlank(Global.ESS_ServiceNow_NextAllRequestsRefresh) && Global.ESS_ServiceNow_NextAllRequestsRefresh > Now() && (Topic.RequestState = "all" || IsBlank(Topic.RequestState))
-          displayName: Requests list is cached?
-          actions:
-            - kind: SetVariable
-              id: useCachedRequests
-              variable: Topic.ServiceNowData
-              value: =Global.ESS_ServiceNow_AllRequests
-
         - id: conditionItem_allRequests
           condition: =Topic.RequestState = "all" || IsBlank(Topic.RequestState)
           displayName: List all requests

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-get-user-requests.mcs.yml
@@ -16,7 +16,7 @@ inputs:
 modelDescription: |-
   This tool retrieves the list of service catalog requests (REQ numbers) for the user.
 
-  Use this tool when a user asks about their requests, service requests, catalog requests, REQ items, or items they requested — NOT for incident tickets (INC), IT support tickets, helpdesk tickets, or support cases. If the user says "requests" without saying ticket, incident, INC, support, or helpdesk, treat it as a service catalog request and use this tool. Use ServiceNow-ITSM-Get-User-Tickets only for incidents or support tickets.
+  Use this tool when a user asks about their service requests, catalog requests, or REQ items — NOT for incident tickets (INC). Use ServiceNow-ITSM-Get-User-Tickets for incidents.
 
   Example queries:
   * "Show me my service requests"
@@ -36,21 +36,7 @@ modelDescription: |-
 beginDialog:
   kind: OnRecognizedIntent
   id: main
-  intent:
-    triggerQueries:
-      - show all my requests
-      - list all my requests
-      - show my requests
-      - list my requests
-      - show me my service requests
-      - list my service requests
-      - what requests do I have open
-      - show my open requests
-      - my pending catalog requests
-      - list my completed requests
-      - what did I request recently
-      - show my REQ items
-
+  intent: {}
   actions:
     - kind: ConditionGroup
       id: conditionGroup_requestState

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-system-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-system-get-user-requests.mcs.yml
@@ -28,7 +28,7 @@ beginDialog:
           servicenowtransactionid: Topic.ServiceNowTransactionID
           statuscode: Topic.StatusCode
 
-      flowId: {FLOW_GUID}
+      flowId: "{FLOW_GUID}"
 
 
 inputType:

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-system-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-system-get-user-requests.mcs.yml
@@ -16,7 +16,7 @@ beginDialog:
       id: callGetUserRequestsFlow
       input:
         binding:
-          text: =Topic.UserIdentifier
+          text: =Coalesce(Topic.UserIdentifier, System.User.PrincipalName)
           text_1: =If(IsBlank(Topic.IsActive), "", Text(Topic.IsActive))
 
       output:

--- a/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-system-get-user-requests.mcs.yml
+++ b/copilot-agent-samples/ESS/servicenow-itsm-get-user-requests/topics/ess-it-servicenow-itsm-system-get-user-requests.mcs.yml
@@ -30,22 +30,6 @@ beginDialog:
 
       flowId: {FLOW_GUID}
 
-    - kind: ConditionGroup
-      id: conditionGroup_cacheResult
-      conditions:
-        - id: conditionItem_cacheAll
-          condition: =!IsBlank(Topic.ServiceNowData) && IsBlank(Topic.IsActive)
-          displayName: Cache all-requests response?
-          actions:
-            - kind: SetVariable
-              id: cacheAllRequests
-              variable: Global.ESS_ServiceNow_AllRequests
-              value: =Topic.ServiceNowData
-
-            - kind: SetVariable
-              id: setCacheExpiry
-              variable: Global.ESS_ServiceNow_NextAllRequestsRefresh
-              value: =DateAdd(Now(), 15, TimeUnit.Minutes)
 
 inputType:
   properties:


### PR DESCRIPTION
Adds publish-ready ServiceNow ITSM samples for Employee Self-Service, covering:

Listing a user’s catalog requests
Retrieving detailed REQ and RITM information
OBO configuration and environment-specific portal links
Importable solution packages and Maker Kit deployment
Correct flow/topic wiring, output contracts, and response handling
Setup guidance, workflow ID clarification, and sample disclaimers
Also fixes flow input validation, missing topic variables, RITM flow wiring, duplicate responses, and normal dialog completion.