### PR TITLE
chore(deps): update js-yaml for CVE-2026-59870

### DIFF
--- a/tools/catalog-build/package-lock.json
+++ b/tools/catalog-build/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "gray-matter": "^4.0.3",
-        "js-yaml": "^5.2.2"
+        "js-yaml": "^5.2.3"
       }
     },
     "node_modules/argparse": {
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha1-WG5SFOr+Pok3VqQel5tQ2J0+Smc=",
+      "version": "3.15.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.2.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha1-CUKuj1B+IusOVGJIcXic1HcQblQ=",
       "dev": true,
       "funding": [
         {

--- a/tools/catalog-build/package.json
+++ b/tools/catalog-build/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "gray-matter": "^4.0.3",
-    "js-yaml": "^5.2.2"
+    "js-yaml": "^5.2.3"
   }
 }


### PR DESCRIPTION
Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

# Category
- [x] Bug fix
- [ ] New script
- [ ] New sample

# Related Issues

Resolves Dependabot alert #155 for CVE-2026-59870 (GHSA-5p4m-2wfm-xmqj).

# What's in this Pull Request?

Updates the direct `js-yaml` dependency to 5.2.3 and `gray-matter`'s transitive dependency from vulnerable 3.15.0 to the first patched 3.x release, 3.15.1.

## Validation

`npm audit --audit-level=high` reports 0 vulnerabilities; before the update it identified GHSA-5p4m-2wfm-xmqj.

`npm run check` validates all 30 catalog resources.