### PR TITLE
chore: omit registry URLs from catalog lockfile

### DIFF
--- a/tools/catalog-build/.npmrc
+++ b/tools/catalog-build/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/tools/catalog-build/package-lock.json
+++ b/tools/catalog-build/package-lock.json
@@ -14,14 +14,12 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -35,7 +33,6 @@
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
@@ -48,7 +45,6 @@
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha1-6JPAZIJd5z6h9ffYjHqfcnQoh5g=",
       "dev": true,
       "license": "MIT",
@@ -64,7 +60,6 @@
     },
     "node_modules/gray-matter/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "license": "MIT",
@@ -74,7 +69,6 @@
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
       "version": "3.15.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
       "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
       "dev": true,
       "license": "MIT",
@@ -88,7 +82,6 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true,
       "license": "MIT",
@@ -98,7 +91,6 @@
     },
     "node_modules/js-yaml": {
       "version": "5.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-5.2.3.tgz",
       "integrity": "sha1-CUKuj1B+IusOVGJIcXic1HcQblQ=",
       "dev": true,
       "funding": [
@@ -121,7 +113,6 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true,
       "license": "MIT",
@@ -131,7 +122,6 @@
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha1-6QQZU1BngOwB1Z8pKhnHuFC4QWc=",
       "dev": true,
       "license": "MIT",
@@ -145,14 +135,12 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
# Category
- [x] Bug fix
- [ ] New script
- [ ] New sample

# Instructions
- [x] No documentation update is needed for this lockfile-generation change.
- [x] Followed the contributing guidance.

# Related Issues

N/A

# What's in this Pull Request?

Adds `tools/catalog-build/.npmrc` with `omit-lockfile-registry-resolved=true` and regenerates the lockfile so registry feed URLs are not committed.

The regenerated lockfile removes 12 `resolved` fields. Dependency names, versions, integrity hashes, and platform metadata are unchanged.

## Validation

- `npx --yes -p node@20 -p npm@10.9.4 -c 'node --version && npm --version && npm config get omit-lockfile-registry-resolved'` returned Node `v20.20.2`, npm `10.9.4`, and `true`.
- A structural lockfile comparison found no changes outside `resolved`; no Microsoft feed URLs remain.
- Repeating `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` left SHA-256 `a904c40418791dd297b4af43da19545473bf909bd9ab8e79b50cf5bec3d95500` unchanged.
- `npm ci --no-audit --no-fund` installed 12 packages.
- `npm run check` passed: `Catalog metadata is valid for 30 resources.`
